### PR TITLE
Connect frontend flows to backend API

### DIFF
--- a/frontend/app/(app)/lost-found/citizen.tsx
+++ b/frontend/app/(app)/lost-found/citizen.tsx
@@ -41,7 +41,9 @@ export default function CitizenLostFound() {
   useEffect(() => {
     fetchFoundItems()
       .then(setFoundItems)
-      .catch(() => toast.error("Failed to load items"))
+      .catch((error: any) =>
+        toast.error(error.response?.data?.message ?? "Failed to load items"),
+      )
       .finally(() => setLoadingItems(false));
   }, []);
 
@@ -80,8 +82,8 @@ export default function CitizenLostFound() {
       resetForm();
       setOpenForm(false);
       router.replace({ pathname: "/incidents/my-reports", params: { role: "citizen", filter: "lost" } });
-    } catch (e) {
-      toast.error("Failed to submit");
+    } catch (e: any) {
+      toast.error(e.response?.data?.message ?? "Failed to submit");
     } finally {
       setSubmitting(false);
     }

--- a/frontend/app/(app)/lost-found/view.tsx
+++ b/frontend/app/(app)/lost-found/view.tsx
@@ -56,6 +56,21 @@ export default function LostFoundView() {
   const [newNoteDraft, setNewNoteDraft] = useState("");
   const [newNoteHeight, setNewNoteHeight] = useState<number | undefined>(undefined);
 
+  const readableStatus = useCallback((value?: string) => {
+    switch (value) {
+      case "PENDING":
+        return "Pending";
+      case "INVESTIGATING":
+        return "Investigating";
+      case "FOUND":
+        return "Found";
+      case "CLOSED":
+        return "Closed";
+      default:
+        return value ?? "Unknown";
+    }
+  }, []);
+
   useEffect(() => {
     const load = async () => {
       try {
@@ -69,15 +84,18 @@ export default function LostFoundView() {
           color: data.color ?? "",
           lastLocation: data.lastLocation ?? "",
         });
-        if (type === "lost" && "status" in data && data.status) setStatus(data.status);
-      } catch {
+        if (type === "lost" && "status" in data && data.status) {
+          setStatus(readableStatus(data.status));
+        }
+      } catch (error: any) {
+        toast.error(error.response?.data?.message ?? "Failed to load item");
         setError(true);
       } finally {
         setLoading(false);
       }
     };
     load();
-  }, [id, type]);
+  }, [id, type, readableStatus]);
 
   // ⇣ Key change: for officers, always honor the tab they came from
   const section = useMemo<Section | undefined>(() => {

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -6,18 +6,13 @@ import {
   useState,
 } from 'react';
 import { useStorageState } from '@/hooks/useStorageState';
+import { fetchProfile } from '@/lib/api';
 import { apiService } from '@/services/apiService';
 
 interface RefreshResponse {
   data: {
     accessToken: string;
     refreshToken: string;
-  };
-}
-
-interface ProfileResponse {
-  data: {
-    is_officer: boolean;
   };
 }
 
@@ -71,12 +66,11 @@ export function AuthProvider({ children }: PropsWithChildren) {
       await setAccessTokenSession(accessToken);
       await setRefreshTokenSession(refreshToken);
 
-      const response = await apiService.get<ProfileResponse>(
-        '/api/v1/auth/profile',
-      );
-
-      if (response.status === 200) {
-        setIsOfficer(response.data.data.is_officer);
+      try {
+        const profile = await fetchProfile();
+        setIsOfficer(profile.isOfficer);
+      } catch {
+        setIsOfficer(false);
       }
     },
     [setAccessTokenSession, setRefreshTokenSession],


### PR DESCRIPTION
## Summary
- replace the mock API helper with axios-powered requests that call the real authentication, alert, incident, and lost-article endpoints (including MFA and token refresh logic)
- update login, registration, MFA, and auth context flows to consume backend responses and pass MFA challenges through to the dedicated screen
- hook the alerts and lost & found screens into the new APIs, reloading data and handling create/delete flows against the server

## Testing
- `npx tsc --noEmit` *(fails: Expo React Native project configuration unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d51b0770bc832a88252b17757af409