### PR TITLE
Connect mobile auth flows to backend

### DIFF
--- a/backend/src/controllers/mfa.controller.js
+++ b/backend/src/controllers/mfa.controller.js
@@ -1,6 +1,12 @@
 const authenticationService = require("src/services/authentication.service");
 const mfaService = require("src/services/mfa.service");
 const HttpResponse = require("src/utils/http-response-helper");
+const HttpError = require("src/utils/http-error");
+const cookieOptions = require("src/config/cookie-options");
+const {
+  ACCESS_TOKEN_COOKIE_NAME,
+  REFRESH_TOKEN_COOKIE_NAME,
+} = require("src/constants/cookies");
 
 class MFAController {
   /**
@@ -8,12 +14,41 @@ class MFAController {
    * @param {import('express').Response} res
    */
   async verifyCode(req, res) {
-    const payload = await mfaService.verifyCode(
-      req.body.mfa_token,
-      req.body.code,
+    const { mfa_token: mfaToken, code } = req.body || {};
+
+    if (!mfaToken || !code) {
+      throw new HttpError({
+        code: 400,
+        clientMessage: "Missing multi-factor authentication details",
+      });
+    }
+
+    const payload = await mfaService.verifyCode(mfaToken, code);
+    const user = await authenticationService.mfaVerified(payload.sub);
+
+    if (!user) {
+      throw new HttpError({ code: 404, clientMessage: "User not found" });
+    }
+
+    const tokens = await authenticationService.generateTokens(
+      user.id,
+      user.is_officer,
     );
-    await authenticationService.mfaVerified(payload.sub);
-    new HttpResponse(204).sendStatus(res);
+
+    if (!tokens || tokens.length < 2) {
+      throw new HttpError({
+        code: 500,
+        clientMessage: "Unable to generate authentication tokens",
+      });
+    }
+
+    const [accessToken, refreshToken] = tokens;
+
+    res
+      .cookie(ACCESS_TOKEN_COOKIE_NAME, accessToken, cookieOptions)
+      .cookie(REFRESH_TOKEN_COOKIE_NAME, refreshToken, cookieOptions);
+
+    new HttpResponse(200, { accessToken, refreshToken }).json(res);
   }
 
   /**
@@ -21,7 +56,16 @@ class MFAController {
    * @param {import('express').Response} res
    */
   async resendCode(req, res) {
-    const payload = await mfaService.verifyToken(req.body.mfa_token);
+    const { mfa_token: mfaToken } = req.body || {};
+
+    if (!mfaToken) {
+      throw new HttpError({
+        code: 400,
+        clientMessage: "Missing multi-factor authentication token",
+      });
+    }
+
+    const payload = await mfaService.verifyToken(mfaToken);
     new HttpResponse(200, {
       mfa_token: await mfaService.generateToken(
         payload.sub,

--- a/frontend/app/(auth)/register.tsx
+++ b/frontend/app/(auth)/register.tsx
@@ -1,6 +1,6 @@
 // app/(auth)/register.tsx
 import { router } from "expo-router";
-import { useRef, useState, useContext } from "react";
+import { useRef, useState } from "react";
 import { ActivityIndicator, Animated, Image, Keyboard, View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 
@@ -11,7 +11,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Text } from "@/components/ui/text";
 import { Lock, Mail, UserRound } from "lucide-react-native";
-import { AuthContext } from "@/context/AuthContext";
 import { apiService } from "@/services/apiService";
 import useMountAnimation from "@/hooks/useMountAnimation";
 
@@ -30,7 +29,6 @@ export default function Register() {
   const [confirm, setConfirm] = useState("");
   const [showPw, setShowPw] = useState(false);
   const [loading, setLoading] = useState(false);
-  const { login } = useContext(AuthContext);
 
   // Focus chain
   const lastNameRef = useRef<any>(null);
@@ -54,19 +52,17 @@ export default function Register() {
     if (!canSubmit || loading) return;
     try {
       setLoading(true);
-      const res = await apiService.post("/api/v1/auth/register", {
-        firstName: sanitize(firstName),
-        lastName: sanitize(lastName),
+      await apiService.post("/api/v1/auth/register", {
+        first_name: sanitize(firstName),
+        last_name: sanitize(lastName),
         username: sanitize(username),
         email: sanitize(email),
         password,
       });
-      const { accessToken, refreshToken } = res.data.data;
-      await login(accessToken, refreshToken);
-      toast.success("Welcome!");
-      router.replace("/home");
+      toast.success("Account created. Please sign in.");
+      router.replace("/login");
     } catch (e: any) {
-      const message = e.response?.data?.message ?? "Registration failed";
+      const message = e.response?.data?.message ?? e.message ?? "Registration failed";
       toast.error(message);
     } finally {
       setLoading(false);

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -98,6 +98,10 @@ export function AuthProvider({ children }: PropsWithChildren) {
         try {
           const response = await apiService.post<RefreshResponse>(
             '/api/v1/auth/refresh',
+            undefined,
+            refreshTokenSession
+              ? { headers: { 'refresh-token': refreshTokenSession } }
+              : undefined,
           );
 
           if (response.status === 200) {
@@ -112,7 +116,12 @@ export function AuthProvider({ children }: PropsWithChildren) {
 
       return false;
     },
-    [lastRefreshCheck, setAccessTokenSession, setRefreshTokenSession],
+    [
+      lastRefreshCheck,
+      refreshTokenSession,
+      setAccessTokenSession,
+      setRefreshTokenSession,
+    ],
   );
 
   const checkAuthed = useCallback(async () => {


### PR DESCRIPTION
## Summary
- return access and refresh tokens from the MFA verification endpoint and validate input for resends
- update the Expo auth screens to call the backend routes, including MFA navigation and register payloads
- ensure the API service and auth context attach refresh tokens so automatic refresh works correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d67e10054c832a880c51c2b1d403cd