### PR TITLE
Fix Expo dev script for Windows compatibility

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,6 +50,7 @@
       "devDependencies": {
         "@babel/core": "^7.26.0",
         "@types/react": "~19.0.14",
+        "cross-env": "^7.0.3",
         "prettier": "^3.6.2",
         "prettier-plugin-tailwindcss": "^0.5.11",
         "typescript": "~5.8.3"
@@ -4163,6 +4164,25 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-fetch": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,10 +3,10 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
-    "dev": "EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c",
-    "android": "EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --android",
-    "ios": "EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --ios",
-    "web": "EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --web",
+    "dev": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c",
+    "android": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --android",
+    "ios": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --ios",
+    "web": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --web",
     "clean": "rm -rf .expo node_modules"
   },
   "dependencies": {
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@types/react": "~19.0.14",
+    "cross-env": "^7.0.3",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.5.11",
     "typescript": "~5.8.3"


### PR DESCRIPTION
## Summary
- use cross-env to set EXPO_PUBLIC_API_URL in Expo scripts so they work on Windows
- add cross-env to devDependencies and lockfile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d69ae69494832a8e00d9e51eada3ed