### PR TITLE
Fix citizen found item access and redirect incident submissions

### DIFF
--- a/backend/test/services/lost-article.test.js
+++ b/backend/test/services/lost-article.test.js
@@ -4,6 +4,7 @@ const sinonChai = require("sinon-chai").default;
 const chaiAsPromised = require("chai-as-promised").default;
 const setupBaseModelStubs = require("../testing-utils/baseModelMocks");
 const lostArticleService = require("src/services/lost-articles.service");
+const personalDetailsService = require("src/services/personal-details.service");
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
@@ -20,6 +21,60 @@ describe("LostArticleService", () => {
 
   afterEach(() => {
     sinon.restore();
+  });
+
+  describe("getById", () => {
+    it("returns the citizen's own lost item", async () => {
+      const item = { id: 1, status: "PENDING" };
+      baseModelStubs.findBy.resolves(item);
+      sinon
+        .stub(personalDetailsService, "findByLostArticleId")
+        .resolves({ data: [{ id: 3 }] });
+
+      const result = await lostArticleService.getById(1, 10);
+
+      expect(baseModelStubs.findBy).to.have.been.calledOnceWithExactly(
+        ["id", "user_id"],
+        [1, 10],
+      );
+      expect(baseModelStubs.findById).to.not.have.been.called;
+      expect(result).to.equal(item);
+      expect(result.personal_details).to.deep.equal([{ id: 3 }]);
+    });
+
+    it("allows citizens to view returned items they do not own", async () => {
+      baseModelStubs.findBy.resolves(null);
+      const returnedItem = { id: 5, status: "FOUND" };
+      baseModelStubs.findById.resolves(returnedItem);
+      sinon
+        .stub(personalDetailsService, "findByLostArticleId")
+        .resolves({ data: [] });
+
+      const result = await lostArticleService.getById(5, 42);
+
+      expect(baseModelStubs.findBy).to.have.been.calledOnceWithExactly(
+        ["id", "user_id"],
+        [5, 42],
+      );
+      expect(baseModelStubs.findById).to.have.been.calledWithExactly(5);
+      expect(result).to.equal(returnedItem);
+      expect(result.personal_details).to.deep.equal([]);
+    });
+
+    it("denies access to non-returned items the citizen does not own", async () => {
+      baseModelStubs.findBy.resolves(null);
+      baseModelStubs.findById.resolves({ id: 7, status: "INVESTIGATING" });
+      const personalDetailsStub = sinon.stub(
+        personalDetailsService,
+        "findByLostArticleId",
+      );
+
+      const result = await lostArticleService.getById(7, 21);
+
+      expect(baseModelStubs.findById).to.have.been.calledWithExactly(7);
+      expect(result).to.be.null;
+      expect(personalDetailsStub).to.not.have.been.called;
+    });
   });
 
   describe("deleteById", () => {

--- a/frontend/app/(app)/incidents/report-incidents.tsx
+++ b/frontend/app/(app)/incidents/report-incidents.tsx
@@ -233,7 +233,10 @@ export default function ReportIncidents() {
           : "Incident submitted";
 
       toast.success(successMessage);
-      router.replace({ pathname: "/home", params: { role: resolvedRole } });
+      router.replace({
+        pathname: "/incidents/my-reports",
+        params: { role: resolvedRole },
+      });
     } catch (error: any) {
       const fallback = witnesses.some(isWitnessComplete)
         ? "Failed to submit incident and witnesses"

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -518,8 +518,9 @@ export async function fetchFoundItems(): Promise<FoundItem[]> {
   const data = await unwrap<any[]>(
     apiService.get<ApiEnvelope<any[]>>("/api/v1/lost-articles/all"),
   );
+  const returnedStatuses = new Set(["FOUND", "CLOSED"]);
   return (Array.isArray(data) ? data : [])
-    .filter((item) => item.status === "FOUND")
+    .filter((item) => returnedStatuses.has(item.status))
     .map((item) => ({
       id: toStringId(item.id),
       title: item.name ?? "Unknown item",


### PR DESCRIPTION
## Summary
- allow citizens to view returned lost articles by falling back to the public record when they are not the reporter
- expand the returned-item filter and cover the new behaviour with unit tests
- redirect incident report submissions to the My Reports screen after success

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd39e932d8832ab09f51c8e436e10f