### PR TITLE
Remove responsive branching from dashboard and alerts layouts

### DIFF
--- a/frontend/app/(app)/home.tsx
+++ b/frontend/app/(app)/home.tsx
@@ -18,6 +18,7 @@ import {
   Pressable,
   RefreshControl,
   View,
+  type ViewStyle,
   useWindowDimensions,
 } from 'react-native';
 
@@ -30,8 +31,6 @@ import { Text } from '@/components/ui/text';
 import { fetchAlerts, fetchLostItems, fetchReports, formatRelativeTime, type AlertRow, type LostItemDetail, type ReportSummary } from '@/lib/api';
 import { cn } from '@/lib/utils';
 import { AuthContext } from '@/context/AuthContext';
-import { useResponsiveLayout } from '@/hooks/useResponsiveLayout';
-
 
 import {
   AlertTriangle,
@@ -96,7 +95,6 @@ export default function Home() {
     profileLoading,
     refreshProfile,
   } = useContext(AuthContext);
-  const layout = useResponsiveLayout();
 
   const role = useMemo<Role>(() => {
     if (params.role === 'officer') return 'officer';
@@ -444,37 +442,22 @@ export default function Home() {
           />
 
               {showBanner ? (
-                <AppCard
-                  className={cn(
-                    'flex-row flex-wrap items-center gap-3 border border-destructive/40',
-                    layout.isCozy && 'flex-col items-start text-left',
-                  )}
-                >
+                <AppCard className="flex-row items-center gap-3 border border-destructive/40 p-4">
                   <View className="h-10 w-10 items-center justify-center rounded-full bg-destructive/10">
                     <AlertTriangle size={18} color="#B91C1C" />
                   </View>
-                  <Text
-                    className={cn(
-                      'text-[13px] text-destructive',
-                      layout.isCozy ? 'text-left' : 'flex-1',
-                    )}
-                  >
+                  <Text className="flex-1 text-[13px] text-destructive">
                     If this is an emergency, please call 119 immediately.
                   </Text>
                 </AppCard>
               ) : null}
 
               {dataError ? (
-                <AppCard
-                  className={cn(
-                    'flex-row flex-wrap items-center gap-3 border border-destructive/40 bg-destructive/10 p-4',
-                    layout.isCozy && 'flex-col items-start text-left',
-                  )}
-                >
+                <AppCard className="flex-row items-center gap-3 border border-destructive/40 bg-destructive/10 p-4">
                   <View className="h-9 w-9 items-center justify-center rounded-full bg-destructive/10">
                     <AlertTriangle size={16} color="#B91C1C" />
                   </View>
-                  <View className={cn('gap-1', layout.isCozy ? 'w-full' : 'flex-1')}>
+                  <View className="flex-1 gap-1">
                     <Text className="text-sm font-semibold text-destructive">Some data failed to load</Text>
                     <Text className="text-xs text-destructive/80" numberOfLines={2}>
                       {dataError}
@@ -484,7 +467,7 @@ export default function Home() {
                     size="sm"
                     variant="secondary"
                     onPress={loadDashboardData}
-                    className={cn('h-9 rounded-full px-3', layout.isCozy && 'w-full justify-center')}
+                    className="h-9 rounded-full px-3"
                     disabled={dataLoading}
                   >
                     <Text className="text-[12px] text-foreground">Retry</Text>
@@ -522,67 +505,64 @@ export default function Home() {
       <View className="gap-6">
           {role === 'officer' ? (
             <>
-              <Animated.View style={animStyle(sectionAnims[0])}>
-                <Card>
-                  <CardHeader title="Overview" tone="ring" />
-                      <View
-                        className={cn(
-                          'mt-3 gap-3',
-                          layout.isCozy ? 'flex-col' : 'flex-row',
-                        )}
-                      >
-                        <Kpi
-                          label="Pending reports"
-                          value={overview.pendingReports}
-                          tone="primary"
-                          trend={trends.pendingReports}
-                        />
-                        <Kpi
-                          label="Ongoing reports"
-                          value={overview.ongoingReports}
-                          tone="ring"
-                          trend={trends.ongoingReports}
-                        />
-                      </View>
-                    </Card>
-                  </Animated.View>
-
-                  <Animated.View style={animStyle(sectionAnims[1])}>
-                    <Card>
-                      <CardHeader title="Manage" tone="primary" />
-                      {/* Order controls left/right columns:
-                          0 (left), 1 (right), 2 (left), 3 (right) */}
-                      <TileGrid
-                        tiles={[
-                          {
-                            label: 'Manage incidents',
-                            icon: Shield,
-                            onPress: goManageIncidentsPending,
-                            count: officerCounts.incidents,
-                          }, // left row 1
-                          {
-                            label: 'Lost items',
-                            icon: PackageSearch,
-                            onPress: goOfficerLostPending,
-                            variant: 'secondary',
-                            count: officerCounts.lostFound,
-                          }, // right row 1
-                          {
-                            label: 'Safety alerts',
-                            icon: BellRing,
-                            onPress: goManageAlerts,
-                            count: officerCounts.alerts,
-                          }, // left row 2
-                          {
-                            label: 'Found items',
-                            icon: PackageSearch,
-                            onPress: goOfficerFound,
-                            variant: 'secondary',
-                          }, // right row 2
-                        ]}
+              <View className="flex-row gap-5" style={{ alignItems: 'stretch' }}>
+                <Animated.View style={[animStyle(sectionAnims[0]), { flex: 1 }]}>
+                  <Card className="flex-1">
+                    <CardHeader title="Overview" tone="ring" />
+                    <View className="mt-3 flex-row gap-3">
+                      <Kpi
+                        label="Pending reports"
+                        value={overview.pendingReports}
+                        tone="primary"
+                        trend={trends.pendingReports}
                       />
-                    </Card>
-                  </Animated.View>
+                      <Kpi
+                        label="Ongoing reports"
+                        value={overview.ongoingReports}
+                        tone="ring"
+                        trend={trends.ongoingReports}
+                      />
+                    </View>
+                  </Card>
+                </Animated.View>
+
+                <Animated.View style={[animStyle(sectionAnims[1]), { flex: 1 }]}>
+                  <Card className="flex-1">
+                    <CardHeader title="Manage" tone="primary" />
+                    {/* Order controls left/right columns:
+                        0 (left), 1 (right), 2 (left), 3 (right) */}
+                    <TileGrid
+                      tiles={[
+                        {
+                          label: 'Manage incidents',
+                          icon: Shield,
+                          onPress: goManageIncidentsPending,
+                          count: officerCounts.incidents,
+                        }, // left row 1
+                        {
+                          label: 'Lost items',
+                          icon: PackageSearch,
+                          onPress: goOfficerLostPending,
+                          variant: 'secondary',
+                          count: officerCounts.lostFound,
+                        }, // right row 1
+                        {
+                          label: 'Safety alerts',
+                          icon: BellRing,
+                          onPress: goManageAlerts,
+                          count: officerCounts.alerts,
+                        }, // left row 2
+                        {
+                          label: 'Found items',
+                          icon: PackageSearch,
+                          onPress: goOfficerFound,
+                          variant: 'secondary',
+                        }, // right row 2
+                      ]}
+                    />
+                  </Card>
+                </Animated.View>
+              </View>
 
                   <Animated.View style={animStyle(sectionAnims[2])}>
                     <Card>
@@ -775,7 +755,15 @@ function alertIconForType(type?: string): IconType {
 /* -------------------- UI Partials -------------------- */
 
 /** Card container with standard padding, border, and rounded corners. */
-const Card: FC<{ children: ReactNode }> = ({ children }) => <AppCard className="gap-4">{children}</AppCard>;
+const Card: FC<{ children: ReactNode; className?: string; style?: ViewStyle }> = ({
+  children,
+  className,
+  style,
+}) => (
+  <AppCard className={cn('gap-4', className)} style={style}>
+    {children}
+  </AppCard>
+);
 
 /**
  * Section header with title, optional action, and tone bar.
@@ -859,24 +847,8 @@ type Tile = {
   count?: number;
 };
 
-/** Responsive 2-column grid of action tiles. */
+/** Two-column grid of action tiles. */
 const TileGrid: FC<{ tiles: Tile[] }> = ({ tiles }) => {
-  const layout = useResponsiveLayout();
-  const effectiveWidth = Math.min(layout.maxContentWidth, layout.width);
-  const singleColumn = effectiveWidth < 320;
-
-  if (singleColumn) {
-    return (
-      <View className="mt-4 gap-3">
-        {tiles.map((tile, idx) => (
-          <View key={`${tile.label}-${idx}`} className="w-full">
-            <IconTileButton {...tile} />
-          </View>
-        ))}
-      </View>
-    );
-  }
-
   const rows: Tile[][] = [];
   for (let i = 0; i < tiles.length; i += 2) {
     rows.push(tiles.slice(i, i + 2));
@@ -885,16 +857,13 @@ const TileGrid: FC<{ tiles: Tile[] }> = ({ tiles }) => {
   return (
     <View className="mt-4 flex-col gap-3">
       {rows.map((row, rowIdx) => (
-        <View
-          key={rowIdx}
-          className={cn('flex-row gap-3', layout.isCozy ? 'flex-col' : undefined)}
-        >
+        <View key={rowIdx} className="flex-row gap-3">
           {row.map((tile, idx) => (
-            <View key={`${tile.label}-${idx}`} className={layout.isCozy ? 'w-full' : 'flex-1'}>
+            <View key={`${tile.label}-${idx}`} className="flex-1">
               <IconTileButton {...tile} />
             </View>
           ))}
-          {row.length === 1 && !layout.isCozy ? <View className="flex-1" /> : null}
+          {row.length === 1 ? <View className="flex-1" /> : null}
         </View>
       ))}
     </View>
@@ -909,13 +878,12 @@ const IconTileButton: FC<Tile> = ({
   variant = 'default',
   count,
 }) => {
-  const layout = useResponsiveLayout();
   const isSecondary = variant === 'secondary';
   const iconColor = isSecondary ? '#0F172A' : '#1E3A8A';
   const circleTint = isSecondary ? '#E0F2F1' : '#E0EAFF';
   const hasBadge = typeof count === 'number' && count > 0;
-  const cardPadding = layout.isCozy ? 'px-5 py-5' : 'px-6 py-6';
-  const minHeight = layout.isCozy ? 136 : 148;
+  const cardPadding = 'px-6 py-6';
+  const minHeight = 148;
 
   return (
     <Pressable
@@ -986,7 +954,6 @@ const List: FC<{
   emptyTone = 'ring',
   onItemPress,
 }) => {
-  const layout = useResponsiveLayout();
   if (!items || items.length === 0) {
     return (
       <AppCard className={cn('mt-3', className)}>
@@ -1001,7 +968,7 @@ const List: FC<{
           <View
             className={cn(
               'flex-row flex-wrap items-center gap-3',
-              layout.isCozy ? 'justify-start' : 'justify-between',
+              'justify-between',
             )}
           >
             <View className="min-w-0 flex-1 flex-row flex-wrap items-center gap-3">


### PR DESCRIPTION
## Summary
- lock the officer Overview and Manage cards into a single two-column row and simplify banner spacing
- streamline tile grid rendering and action button sizing to avoid breakpoint-specific adjustments
- update the Manage Alerts screen to use consistent padding and a fixed two-column grouping when multiple cards are present

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd53ce4be0832a8dcfee7c0746a12a