### PR TITLE
Configure Dialogflow credentials loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ Guardian is community policing application, essentially an online portal which e
 # 3. Install dependencies
     npm install
 
-# 4. Set env variables by renaming the .env.example file to .env
-# replace necessary values such as your mapbox public token key,
-# set chatbot json file location (after placing the file in the directory) and chatbot project name
+# 4. Set env variables by copying backend/.env.example to backend/.env
+# replace necessary values such as your mapbox public token key.
+# For Dialogflow integration update DF_PROJECT_ID and either
+# GOOGLE_APPLICATION_CREDENTIALS or DF_SERVICE_ACCOUNT_PATH to point to your chatbot
+# service-account JSON (the file itself should stay outside of version control).
 
 # 5. (For Windows) Run the following command in /backend which copies a tensorflow file
 # to another destination which windows fail to do for some reason by its own

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,30 @@
+# Server configuration
+PORT=2699
+NODE_ENV=development
+
+# External services
+MAP_BOX_TOKEN=your_mapbox_public_token
+
+# Dialogflow / Google Cloud credentials
+DF_PROJECT_ID=your_dialogflow_project_id
+# Relative paths are resolved from the backend/ directory.
+# Option 1: point directly to the credential file Google libraries expect.
+GOOGLE_APPLICATION_CREDENTIALS=./chatbot.json
+# Option 2: provide an alternate variable that will be resolved at runtime.
+DF_SERVICE_ACCOUNT_PATH=
+
+# Authentication and security
+JWT_ACCESS_SECRET=replace_me_with_a_secure_random_string
+JWT_REFRESH_SECRET=replace_me_with_a_secure_random_string
+JWT_FILES_SECRET=replace_me_with_a_secure_random_string
+JWT_MFA_SECRET=replace_me_with_a_secure_random_string
+ACCOUNT_LOCK_ATTEMPTS=5
+ACCOUNT_LOCKOUT_SECONDS=300
+# Optional: override the fallback hash used for dummy password comparisons.
+DUMMY_HASH=
+
+# Email (SMTP) configuration
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=

--- a/backend/src/config/google-cloud.js
+++ b/backend/src/config/google-cloud.js
@@ -1,0 +1,36 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function resolveCredentialPath(candidatePath) {
+  if (!candidatePath?.trim()) {
+    return null;
+  }
+
+  const resolvedPath = path.isAbsolute(candidatePath)
+    ? candidatePath
+    : path.resolve(process.cwd(), candidatePath);
+
+  if (!fs.existsSync(resolvedPath)) {
+    console.warn(
+      `[Dialogflow] Service account file not found at "${resolvedPath}". ` +
+        "Dialogflow requests will fail until the file is available.",
+    );
+    return null;
+  }
+
+  return resolvedPath;
+}
+
+function configureGoogleCloudCredentials() {
+  const configuredPath =
+    process.env.GOOGLE_APPLICATION_CREDENTIALS ||
+    process.env.DF_SERVICE_ACCOUNT_PATH;
+
+  const resolvedPath = resolveCredentialPath(configuredPath);
+
+  if (resolvedPath) {
+    process.env.GOOGLE_APPLICATION_CREDENTIALS = resolvedPath;
+  }
+}
+
+module.exports = configureGoogleCloudCredentials;

--- a/backend/start.js
+++ b/backend/start.js
@@ -1,4 +1,9 @@
 require("dotenv").config();
+
+const configureGoogleCloudCredentials = require("./src/config/google-cloud");
+
+configureGoogleCloudCredentials();
+
 process.env.NODE_PATH = process.env.NODE_PATH || ".";
 require("node:module").Module._initPaths();
 require("./src/server");


### PR DESCRIPTION
## Summary
- add a bootstrap that resolves the Dialogflow service-account path before starting the backend
- provide a backend/.env.example file documenting the required environment variables
- update the setup instructions to cover the new environment configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de7ac2a7dc832ab4fc0cc0af253679