### PR TITLE
Add community map screen with initial Mapbox integration

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,6 +13,7 @@ npx react-native-reusables/cli@latest init -t .
 - Refined the color palette for improved contrast while retaining existing tokens.
 - Simplified the citizen safety alerts preview by removing category filters.
 - Added a username field to the citizen sign-up flow.
+- Started the Mapbox integration with a dedicated community map screen.
 
 ## Getting Started
 
@@ -46,6 +47,20 @@ npm run dev
 ```
 
 If the variable is not set, network requests will fail.
+
+### Mapbox maps (preview)
+
+The new community map screen uses [Mapbox Maps](https://www.mapbox.com/). To enable it locally:
+
+1. Create a Mapbox access token with **Styles: Read** permissions.
+2. Export the token before starting Expo:
+
+   ```bash
+   export EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN="pk.your-token-here"
+   npm run dev
+   ```
+
+The map currently runs on iOS and Android using a custom development client or production build. The web fallback will show a message until web support is added.
 
 ## Adding components
 

--- a/frontend/app/(app)/_layout.tsx
+++ b/frontend/app/(app)/_layout.tsx
@@ -24,6 +24,7 @@ export default function AppLayout() {
       <Stack.Screen name="incidents" />
       <Stack.Screen name="alerts" />
       <Stack.Screen name="lost-found" />
+      <Stack.Screen name="map" />
     </Stack>
   );
 }

--- a/frontend/app/(app)/home.tsx
+++ b/frontend/app/(app)/home.tsx
@@ -44,6 +44,7 @@ import {
   FileText,
   Inbox,
   LayoutDashboard,
+  Map,
   Megaphone,
   MessageSquare,
   PackageSearch,
@@ -410,6 +411,9 @@ export default function Home() {
   const goOfficerFound = () =>
     router.push({ pathname: '/lost-found/officer-found', params: { role } });
 
+  // Map routes
+  const goCommunityMap = () => router.push({ pathname: '/map', params: { role } });
+
   // Safety alerts routes
   const goCitizenAlerts = () => router.push({ pathname: '/alerts/citizen', params: { role } });
 
@@ -549,8 +553,7 @@ export default function Home() {
                 >
                   <Card className={!layout.isCozy ? 'flex-1' : undefined}>
                     <CardHeader title="Manage" tone="primary" />
-                    {/* Order controls left/right columns:
-                        0 (left), 1 (right), 2 (left), 3 (right) */}
+                    {/* Order controls left/right columns in pairs (0 left, 1 right, etc.). */}
                     <TileGrid
                       tiles={[
                         {
@@ -578,6 +581,12 @@ export default function Home() {
                           onPress: goOfficerFound,
                           variant: 'secondary',
                         }, // right row 2
+                        {
+                          label: 'Command map',
+                          icon: Map,
+                          onPress: goCommunityMap,
+                          variant: 'secondary',
+                        }, // left row 3
                       ]}
                     />
                   </Card>
@@ -659,6 +668,12 @@ export default function Home() {
                             onPress: goCitizenAlerts,
                             variant: 'secondary',
                             count: citizenCounts.alerts,
+                          },
+                          {
+                            label: 'Community Map',
+                            icon: Map,
+                            onPress: goCommunityMap,
+                            variant: 'secondary',
                           },
                         ]}
                       />

--- a/frontend/app/(app)/map.tsx
+++ b/frontend/app/(app)/map.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useState } from 'react';
+import { ActivityIndicator, Platform, StyleSheet, View } from 'react-native';
+import { router } from 'expo-router';
+
+import { AppCard, AppScreen, ScreenHeader } from '@/components/app/shell';
+import { Text } from '@/components/ui/text';
+import MapboxGL, { isMapboxConfigured } from '@/lib/mapbox';
+
+import { Map as MapIcon } from 'lucide-react-native';
+
+const DEFAULT_CENTER: [number, number] = [-73.985664, 40.748514];
+
+export default function CommunityMapScreen() {
+  const [mapLoaded, setMapLoaded] = useState(false);
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace('/home');
+    }
+  }, []);
+
+  const handleMapLoaded = useCallback(() => {
+    setMapLoaded(true);
+  }, []);
+
+  const isWeb = Platform.OS === 'web';
+
+  return (
+    <AppScreen scroll={false} contentClassName="flex-1">
+      <ScreenHeader
+        title="Community map"
+        subtitle="Visualise incidents, alerts, and resources"
+        onBack={handleBack}
+        icon={MapIcon}
+      />
+
+      <AppCard className="flex-1 overflow-hidden" style={styles.mapCard}>
+        {isWeb ? (
+          <View style={styles.message}>
+            <Text className="text-center text-sm text-muted-foreground">
+              The interactive map is currently available on iOS and Android builds.
+              Use a native development client or production build to explore the map experience.
+            </Text>
+          </View>
+        ) : !isMapboxConfigured ? (
+          <View style={styles.message}>
+            <Text className="text-center text-sm text-muted-foreground">
+              Mapbox is not configured yet. Set the EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN environment variable
+              before starting the app to enable the interactive map.
+            </Text>
+          </View>
+        ) : (
+          <View style={styles.mapWrapper}>
+            <MapboxGL.MapView
+              style={styles.map}
+              styleURL={MapboxGL.StyleURL.Street}
+              compassEnabled
+              logoEnabled={false}
+              onDidFinishLoadingMap={handleMapLoaded}
+            >
+              <MapboxGL.Camera
+                centerCoordinate={DEFAULT_CENTER}
+                zoomLevel={12}
+                animationMode="flyTo"
+                animationDuration={0}
+              />
+
+              <MapboxGL.PointAnnotation id="guardian-default" coordinate={DEFAULT_CENTER}>
+                <View style={styles.annotation} />
+              </MapboxGL.PointAnnotation>
+            </MapboxGL.MapView>
+
+            {!mapLoaded ? (
+              <View style={styles.loadingOverlay} pointerEvents="none">
+                <ActivityIndicator size="small" />
+                <Text className="mt-2 text-xs text-muted-foreground">Loading map…</Text>
+              </View>
+            ) : null}
+          </View>
+        )}
+      </AppCard>
+    </AppScreen>
+  );
+}
+
+const styles = StyleSheet.create({
+  mapCard: {
+    padding: 0,
+  },
+  mapWrapper: {
+    flex: 1,
+    minHeight: 320,
+  },
+  map: {
+    flex: 1,
+  },
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(248, 250, 252, 0.85)',
+  },
+  message: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+  },
+  annotation: {
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    backgroundColor: '#2563EB',
+    borderWidth: 2,
+    borderColor: '#FFFFFF',
+    shadowColor: '#0F172A',
+    shadowOpacity: 0.3,
+    shadowRadius: 4,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
+  },
+});

--- a/frontend/lib/mapbox.ts
+++ b/frontend/lib/mapbox.ts
@@ -1,0 +1,25 @@
+import MapboxGL from '@rnmapbox/maps';
+
+const rawToken = process.env.EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN;
+const token = typeof rawToken === 'string' && rawToken !== 'undefined' ? rawToken : undefined;
+
+if (token) {
+  MapboxGL.setAccessToken(token);
+} else if (__DEV__) {
+  console.warn(
+    'Mapbox access token is not configured. Set EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN to enable the map view.',
+  );
+}
+
+try {
+  MapboxGL.setTelemetryEnabled(false);
+} catch (error) {
+  if (__DEV__) {
+    console.warn('Unable to configure Mapbox telemetry.', error);
+  }
+}
+
+export const MAPBOX_ACCESS_TOKEN = token;
+export const isMapboxConfigured = typeof token === 'string' && token.length > 0;
+
+export default MapboxGL;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@rn-primitives/label": "^1.2.0",
         "@rn-primitives/portal": "~1.3.0",
         "@rn-primitives/slot": "^1.2.0",
+        "@rnmapbox/maps": "^10.1.45",
         "axios": "^1.7.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2861,6 +2862,39 @@
         }
       }
     },
+    "node_modules/@rnmapbox/maps": {
+      "version": "10.1.45",
+      "resolved": "https://registry.npmjs.org/@rnmapbox/maps/-/maps-10.1.45.tgz",
+      "integrity": "sha512-Rk6Yu5euDnYZDsFPFgQ1Rvp5e2IrTMIjtl6OYj9e/OMSuRGufNSa6P6tt0SwOnUG6QHUcle0c9jhsSL9VQBtTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/along": "6.5.0",
+        "@turf/distance": "6.5.0",
+        "@turf/helpers": "6.5.0",
+        "@turf/length": "6.5.0",
+        "@turf/nearest-point-on-line": "6.5.0",
+        "@types/geojson": "^7946.0.7",
+        "debounce": "^2.2.0"
+      },
+      "peerDependencies": {
+        "expo": ">=47.0.0",
+        "mapbox-gl": "^2.9.0",
+        "react": ">=16.6.1",
+        "react-dom": ">= 17.0.0",
+        "react-native": ">=0.59.9"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "mapbox-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -2888,6 +2922,197 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@turf/along": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/along/-/along-6.5.0.tgz",
+      "integrity": "sha512-LLyWQ0AARqJCmMcIEAXF4GEu8usmd4Kbz3qk1Oy5HoRNpZX47+i5exQtmIWKdqJ1MMhW26fCTXgpsEs5zgJ5gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "^6.5.0",
+        "@turf/destination": "^6.5.0",
+        "@turf/distance": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.2.0.tgz",
+      "integrity": "sha512-wzHEjCXlYZiDludDbXkpBSmv8Zu6tPGLmJ1sXQ6qDwpLE1Ew3mcWqt8AaxfTP5QwDNQa3sf2vvgTEzNbPQkCiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^7.2.0",
+        "@turf/meta": "^7.2.0",
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox/node_modules/@turf/helpers": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.2.0.tgz",
+      "integrity": "sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "tslib": "^2.8.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bbox/node_modules/@turf/meta": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.2.0.tgz",
+      "integrity": "sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^7.2.0",
+        "@types/geojson": "^7946.0.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/bearing": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/bearing/-/bearing-6.5.0.tgz",
+      "integrity": "sha512-dxINYhIEMzgDOztyMZc20I7ssYVNEpSv04VbMo5YPQsqa80KO3TFvbuCahMsCAW5z8Tncc8dwBlEFrmRjJG33A==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/destination": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/destination/-/destination-6.5.0.tgz",
+      "integrity": "sha512-4cnWQlNC8d1tItOz9B4pmJdWpXqS0vEvv65bI/Pj/genJnsL7evI0/Xw42RvEGROS481MPiU80xzvwxEvhQiMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/distance": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/distance/-/distance-6.5.0.tgz",
+      "integrity": "sha512-xzykSLfoURec5qvQJcfifw/1mJa+5UwByZZ5TZ8iaqjGYN0vomhV9aiSLeYdUGtYRESZ+DYC/OzY+4RclZYgMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
+      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/invariant": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
+      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/length": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/length/-/length-6.5.0.tgz",
+      "integrity": "sha512-5pL5/pnw52fck3oRsHDcSGrj9HibvtlrZ0QNy2OcW8qBFDNgZ4jtl6U7eATVoyWPKBHszW3dWETW+iLV7UARig==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/distance": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-intersect": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.5.0.tgz",
+      "integrity": "sha512-CS6R1tZvVQD390G9Ea4pmpM6mJGPWoL82jD46y0q1KSor9s6HupMIo1kY4Ny+AEYQl9jd21V3Scz20eldpbTVA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/line-segment": "^6.5.0",
+        "@turf/meta": "^6.5.0",
+        "geojson-rbush": "3.x"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/line-segment": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.5.0.tgz",
+      "integrity": "sha512-jI625Ho4jSuJESNq66Mmi290ZJ5pPZiQZruPVpmHkUw257Pew0alMmb6YrqYNnLUuiVVONxAAKXUVeeUGtycfw==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/nearest-point-on-line": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/nearest-point-on-line/-/nearest-point-on-line-6.5.0.tgz",
+      "integrity": "sha512-WthrvddddvmymnC+Vf7BrkHGbDOUu6Z3/6bFYUGv1kxw8tiZ6n83/VG6kHz4poHOfS0RaNflzXSkmCi64fLBlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bearing": "^6.5.0",
+        "@turf/destination": "^6.5.0",
+        "@turf/distance": "^6.5.0",
+        "@turf/helpers": "^6.5.0",
+        "@turf/invariant": "^6.5.0",
+        "@turf/line-intersect": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
       }
     },
     "node_modules/@types/babel__core": {
@@ -2926,6 +3151,12 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
@@ -4318,6 +4549,18 @@
         "node": ">= 12"
       }
     },
+    "node_modules/debounce": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-2.2.0.tgz",
+      "integrity": "sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -5510,6 +5753,25 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/geojson-rbush": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.2.0.tgz",
+      "integrity": "sha512-oVltQTXolxvsz1sZnutlSuLDEcQAKYC/uXt9zDzJJ6bu0W+baTI8LZBaTup5afzibEH4N3jlq2p+a152wlBJ7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@turf/bbox": "*",
+        "@turf/helpers": "6.x",
+        "@turf/meta": "6.x",
+        "@types/geojson": "7946.0.8",
+        "rbush": "^3.0.1"
+      }
+    },
+    "node_modules/geojson-rbush/node_modules/@types/geojson": {
+      "version": "7946.0.8",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
+      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA==",
+      "license": "MIT"
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -8281,6 +8543,12 @@
         }
       ]
     },
+    "node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "license": "ISC"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -8301,6 +8569,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rbush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
+      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
+      "license": "MIT",
+      "dependencies": {
+        "quickselect": "^2.0.0"
       }
     },
     "node_modules/rc": {
@@ -10097,6 +10374,12 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "@rn-primitives/label": "^1.2.0",
     "@rn-primitives/portal": "~1.3.0",
     "@rn-primitives/slot": "^1.2.0",
+    "@rnmapbox/maps": "^10.1.45",
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Summary
- add the @rnmapbox/maps dependency with a helper that wires up the access token and telemetry configuration
- introduce a community map screen that renders a Mapbox map with graceful fallbacks when running on web or without a token
- expose the new map entry point from the dashboard, register the route, and document the required EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e112016e68832aa2678b662bc07e0b