### PR TITLE
Scope lost item reports and clean incident metadata

### DIFF
--- a/frontend/app/(app)/incidents/my-reports.tsx
+++ b/frontend/app/(app)/incidents/my-reports.tsx
@@ -1,44 +1,63 @@
 // app/(app)/incidents/my-reports.tsx
 import { useNavigation } from "@react-navigation/native";
-import { router } from "expo-router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { router, useLocalSearchParams } from "expo-router";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Pressable, View } from "react-native";
 
 import { AppCard, AppScreen, Pill, ScreenHeader, SectionHeader } from "@/components/app/shell";
 import { Button } from "@/components/ui/button";
 import { Text } from "@/components/ui/text";
 import { toast } from "@/components/toast";
-import { fetchReports, type ReportSummary } from "@/lib/api";
+import {
+  fetchLostItems,
+  fetchReports,
+  formatRelativeTime,
+  type LostItemDetail,
+  type ReportSummary,
+} from "@/lib/api";
 
-import { ChevronRight, ClipboardList, Inbox } from "lucide-react-native";
+import { AuthContext } from "@/context/AuthContext";
+
+import { ChevronRight, ClipboardList, Inbox, PackageSearch, ShieldPlus } from "lucide-react-native";
 
 /** Types */
 type Priority = "Urgent" | "Normal" | "Low";
-type Status = "New" | "In Review" | "Approved" | "Assigned" | "Ongoing" | "Resolved";
+type KindFilter = "All" | "Incidents" | "Lost";
 
 type Row = {
   id: string;
+  resourceId: string;
   title: string;
-  status: Status;
-  priority: Priority;
+  status: string;
   reportedAgo: string;
+  priority?: Priority | null;
+  kind: "incident" | "lost";
+  meta?: string;
+  category?: string | null;
 };
 
-const statusTone = (s: Status) =>
-  s === "Resolved" ? "text-muted-foreground"
-  : s === "Ongoing" || s === "Assigned" || s === "Approved" ? "text-ring"
-  : s === "In Review" ? "text-primary"
-  : "text-foreground";
+const statusTone = (s: string) =>
+  s === "Resolved" || s === "Returned"
+    ? "text-muted-foreground"
+    : s === "Ongoing" || s === "Assigned" || s === "Approved" || s === "Searching"
+    ? "text-ring"
+    : s === "In Review" || s === "New"
+    ? "text-primary"
+    : "text-foreground";
 
 /** Screen */
 export default function MyReports() {
   const navigation = useNavigation<any>();
+  const { profile, profileLoading } = useContext(AuthContext);
   const goBack = useCallback(() => {
     if (navigation?.canGoBack?.()) navigation.goBack();
     else router.replace({ pathname: "/home", params: { role: "citizen" } });
   }, [navigation]);
 
+  const params = useLocalSearchParams<{ filter?: string }>();
+
   const [reports, setReports] = useState<ReportSummary[]>([]);
+  const [lostItems, setLostItems] = useState<LostItemDetail[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -46,8 +65,12 @@ export default function MyReports() {
     setLoading(true);
     setError(null);
     try {
-      const data = await fetchReports();
-      setReports(data);
+      const [incidentData, lostData] = await Promise.all([
+        fetchReports(),
+        fetchLostItems(),
+      ]);
+      setReports(incidentData);
+      setLostItems(lostData);
     } catch (err: any) {
       const message = err?.response?.data?.message || err?.message || "Failed to load reports";
       setError(message);
@@ -61,33 +84,85 @@ export default function MyReports() {
     loadReports();
   }, [loadReports]);
 
-  const all = useMemo<Row[]>(
-    () =>
-      reports.map(
-        (report): Row => ({
-          id: report.id,
-          title: report.title,
-          status: report.status,
-          priority: report.suggestedPriority,
-          reportedAgo: report.reportedAgo,
-        }),
-      ),
-    [reports],
-  );
+  const all = useMemo<Row[]>(() => {
+    const userId = profile?.id ?? null;
+    const userLabel = userId ? `Citizen #${userId}` : null;
+    const incidentRows = reports.map(
+      (report): Row => ({
+        id: `incident-${report.id}`,
+        resourceId: report.id,
+        title: report.title,
+        status: report.status,
+        priority: report.suggestedPriority,
+        reportedAgo: report.reportedAgo,
+        kind: "incident",
+        category: report.category ?? null,
+      }),
+    );
+    const lostRows = lostItems
+      .filter((item) => {
+        if (!userId) return false;
+        if (item.reportedById) return item.reportedById === userId;
+        if (userLabel) return item.reportedBy === userLabel;
+        return false;
+      })
+      .map((item): Row => {
+      const subtitleParts = [item.branch, item.lastLocation].filter(
+        (part): part is string => Boolean(part && part.trim()),
+      );
+      return {
+        id: `lost-${item.id}`,
+        resourceId: item.id,
+        title: item.name?.trim() ? item.name : "Lost item report",
+        status: item.status ?? "In Review",
+        reportedAgo: formatRelativeTime(item.createdAt ?? null),
+        priority: null,
+        kind: "lost",
+        meta: subtitleParts.join(" • "),
+      };
+    });
+    return [...incidentRows, ...lostRows];
+  }, [reports, lostItems, profile?.id]);
 
-  const [filter, setFilter] = useState<"All" | "Pending" | "Ongoing" | "Resolved">("All");
+  const [categoryFilter, setCategoryFilter] = useState<KindFilter>("All");
+  const [statusFilter, setStatusFilter] = useState<"All" | "Pending" | "Ongoing" | "Resolved">("All");
+
+  useEffect(() => {
+    const initialFilter = params?.filter;
+    if (typeof initialFilter === "string") {
+      if (initialFilter.toLowerCase() === "lost") {
+        setCategoryFilter("Lost");
+      } else if (initialFilter.toLowerCase() === "incidents") {
+        setCategoryFilter("Incidents");
+      }
+    }
+  }, [params?.filter]);
+
   const filtered = useMemo(() => {
-    if (filter === "All") return all;
-    if (filter === "Pending") return all.filter((r) => r.status === "New" || r.status === "In Review");
-    if (filter === "Ongoing")
-      return all.filter((r) => r.status === "Approved" || r.status === "Assigned" || r.status === "Ongoing");
-    return all.filter((r) => r.status === "Resolved");
-  }, [all, filter]);
+    return all.filter((row) => {
+      if (categoryFilter === "Incidents" && row.kind !== "incident") return false;
+      if (categoryFilter === "Lost" && row.kind !== "lost") return false;
+      if (statusFilter === "All") return true;
+      if (statusFilter === "Pending") return row.status === "New" || row.status === "In Review";
+      if (statusFilter === "Ongoing") {
+        return ["Approved", "Assigned", "Ongoing", "Searching"].includes(row.status);
+      }
+      return row.status === "Resolved" || row.status === "Returned";
+    });
+  }, [all, categoryFilter, statusFilter]);
+
+  const showInitialLoading = (loading && all.length === 0) || (profileLoading && all.length === 0);
 
   const priorityTone: Record<Priority, "danger" | "accent" | "primary"> = {
     Urgent: "danger",
     Normal: "accent",
     Low: "primary",
+  };
+
+  const categoryLabels: Record<KindFilter, string> = {
+    All: "All reports",
+    Incidents: "Incidents",
+    Lost: "Lost items",
   };
 
   return (
@@ -120,12 +195,32 @@ export default function MyReports() {
         />
 
         <View className="flex-row flex-wrap gap-2">
+          {(["All", "Incidents", "Lost"] as const).map((kind) => {
+            const active = categoryFilter === kind;
+            return (
+              <Pressable
+                key={kind}
+                onPress={() => setCategoryFilter(kind)}
+                className={`rounded-full border px-3 py-1 ${
+                  active ? "border-transparent bg-primary/15" : "border-border bg-background"
+                }`}
+                android_ripple={{ color: "rgba(0,0,0,0.06)", borderless: false }}
+              >
+                <Text className={`text-xs font-medium ${active ? "text-foreground" : "text-muted-foreground"}`}>
+                  {categoryLabels[kind]}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <View className="flex-row flex-wrap gap-2">
           {(["All", "Pending", "Ongoing", "Resolved"] as const).map((f) => {
-            const active = filter === f;
+            const active = statusFilter === f;
             return (
               <Pressable
                 key={f}
-                onPress={() => setFilter(f)}
+                onPress={() => setStatusFilter(f)}
                 className={`rounded-full border px-3 py-1 ${
                   active ? "border-transparent bg-primary/10" : "border-border bg-background"
                 }`}
@@ -138,7 +233,7 @@ export default function MyReports() {
         </View>
 
         <View className="gap-3">
-          {loading && all.length === 0 ? (
+          {showInitialLoading ? (
             <View className="items-center gap-3 rounded-2xl border border-dashed border-border bg-muted/30 p-6">
               <ActivityIndicator size="small" color="#0F172A" />
               <Text className="text-sm font-semibold text-foreground">Loading reports…</Text>
@@ -170,9 +265,16 @@ export default function MyReports() {
             filtered.map((r) => (
               <Pressable
                 key={r.id}
-                onPress={() =>
-                  router.push({ pathname: "/incidents/view", params: { id: r.id, role: "citizen" } })
-                }
+                onPress={() => {
+                  if (r.kind === "incident") {
+                    router.push({ pathname: "/incidents/view", params: { id: r.resourceId, role: "citizen" } });
+                  } else {
+                    router.push({
+                      pathname: "/lost-found/view",
+                      params: { id: r.resourceId, type: "lost", role: "citizen" },
+                    });
+                  }
+                }}
                 className="rounded-2xl border border-border bg-background px-4 py-4"
                 android_ripple={{ color: "rgba(0,0,0,0.04)", borderless: false }}
               >
@@ -183,14 +285,26 @@ export default function MyReports() {
                     </Text>
                     <View className="mt-1 flex-row flex-wrap items-center gap-2">
                       <Text className={`text-xs font-medium ${statusTone(r.status)}`}>{r.status}</Text>
+                      {r.category ? (
+                        <Text className="text-xs text-muted-foreground">• {r.category}</Text>
+                      ) : null}
                       <Text className="text-xs text-muted-foreground">• {r.reportedAgo}</Text>
                     </View>
+                    {r.meta ? (
+                      <Text className="mt-1 text-xs text-muted-foreground" numberOfLines={2}>
+                        {r.meta}
+                      </Text>
+                    ) : null}
                   </View>
-                  <Pill
-                    tone={priorityTone[r.priority]}
-                    label={`Priority: ${r.priority}`}
-                    className="self-start"
-                  />
+                  {r.kind === "incident" ? (
+                    <Pill
+                      tone={priorityTone[(r.priority ?? "Normal") as Priority]}
+                      label={`Priority: ${r.priority ?? "Normal"}`}
+                      className="self-start"
+                    />
+                  ) : (
+                    <Pill tone="accent" label="Lost item" className="self-start" />
+                  )}
                 </View>
                 <View className="mt-3 flex-row justify-end">
                   <ChevronRight size={18} color="#94A3B8" />
@@ -201,17 +315,41 @@ export default function MyReports() {
         </View>
       </AppCard>
 
-      <AppCard translucent className="items-center gap-3">
-        <Text className="text-sm font-medium text-foreground">Need to report something new?</Text>
-        <Text className="text-center text-xs text-muted-foreground">
-          Start a fresh report whenever you notice an issue in your neighborhood.
+      <AppCard translucent className="gap-4">
+        <Text className="text-sm font-semibold text-foreground">File a new report</Text>
+        <Text className="text-xs text-muted-foreground">
+          Choose the option that matches what you need help with right now.
         </Text>
-        <Button
-          onPress={() => router.push({ pathname: "/incidents", params: { role: "citizen" } })}
-          className="h-12 rounded-2xl px-5"
-        >
-          <Text className="text-primary-foreground">Report a New Incident</Text>
-        </Button>
+        <View className="flex-row flex-wrap gap-3">
+          <Pressable
+            onPress={() =>
+              router.push({ pathname: "/incidents/report-incidents", params: { role: "citizen" } })
+            }
+            className="flex-1 min-w-[150px] rounded-2xl border border-border bg-background/90 p-4"
+            android_ripple={{ color: "rgba(15,23,42,0.06)", borderless: false }}
+          >
+            <View className="mb-3 h-10 w-10 items-center justify-center rounded-full bg-primary/10">
+              <ShieldPlus size={18} color="#4338CA" />
+            </View>
+            <Text className="text-sm font-semibold text-foreground">Report an incident</Text>
+            <Text className="mt-1 text-[11px] text-muted-foreground">
+              Share what happened so responders can follow up quickly.
+            </Text>
+          </Pressable>
+          <Pressable
+            onPress={() => router.push({ pathname: "/lost-found/citizen", params: { role: "citizen" } })}
+            className="flex-1 min-w-[150px] rounded-2xl border border-border bg-background/90 p-4"
+            android_ripple={{ color: "rgba(15,23,42,0.06)", borderless: false }}
+          >
+            <View className="mb-3 h-10 w-10 items-center justify-center rounded-full bg-accent/10">
+              <PackageSearch size={18} color="#0F172A" />
+            </View>
+            <Text className="text-sm font-semibold text-foreground">Report a lost item</Text>
+            <Text className="mt-1 text-[11px] text-muted-foreground">
+              Tell us what went missing and we’ll link you to the lost &amp; found desk.
+            </Text>
+          </Pressable>
+        </View>
       </AppCard>
     </AppScreen>
   );

--- a/frontend/app/(app)/incidents/report-incidents.tsx
+++ b/frontend/app/(app)/incidents/report-incidents.tsx
@@ -265,7 +265,7 @@ export default function ReportIncidents() {
       });
 
       const detailSegments = [desc.trim()];
-      if (category) detailSegments.unshift(`[${category}]`);
+      if (category) detailSegments.push(`Category: ${category}`);
       if (location) {
         const label = location.label ?? formatCoordinates(location.latitude, location.longitude);
         detailSegments.push(`Location: ${label}`);
@@ -401,12 +401,22 @@ export default function ReportIncidents() {
                 </View>
               </View>
 
+              <View className="flex-row items-start gap-3 rounded-3xl border border-primary/20 bg-primary/5 px-4 py-3">
+                <AlertTriangle size={16} color="#4338CA" style={{ marginTop: 2 }} />
+                <View className="flex-1">
+                  <Text className="text-xs font-semibold text-primary">Be as specific as possible</Text>
+                  <Text className="mt-1 text-[11px] text-primary/80">
+                    Include the timeline, people involved, and any evidence or photos so officers can respond quickly.
+                  </Text>
+                </View>
+              </View>
+
               <View className="gap-2">
                 <Label nativeID="descLabel" className="text-xs font-semibold text-muted-foreground">
                   <Text className="text-xs text-muted-foreground">Description</Text>
                 </Label>
-                <View className="relative">
-                  <NotebookPen size={16} color="#94A3B8" style={{ position: "absolute", left: 14, top: 16 }} />
+                <View className="relative overflow-hidden rounded-3xl border border-border/80 bg-background/80 shadow-sm shadow-black/5">
+                  <NotebookPen size={16} color="#64748B" style={{ position: "absolute", left: 18, top: 18 }} />
                   <Input
                     aria-labelledby="descLabel"
                     value={desc}
@@ -416,22 +426,11 @@ export default function ReportIncidents() {
                       setDescHeight(Math.max(100, Math.min(h, 220)));
                     }}
                     placeholder="What happened?"
-                    className="rounded-2xl bg-background/60 pl-11"
-                    style={{ minHeight: 120, height: descHeight, paddingTop: 16, textAlignVertical: "top" }}
+                    className="rounded-3xl border-0 bg-transparent pl-12 pr-4"
+                    style={{ minHeight: 128, height: descHeight, paddingTop: 18, textAlignVertical: "top" }}
                     multiline
                     maxLength={DESC_MAX}
                   />
-                </View>
-                <View className="flex-row items-center justify-between">
-                  <Text className="text-[11px] text-muted-foreground">Be as specific as possible.</Text>
-                  <Text
-                    className={
-                      "text-[11px] font-medium " +
-                      (desc.length >= DESC_MAX - 20 ? "text-destructive" : "text-muted-foreground")
-                    }
-                  >
-                    {desc.length}/{DESC_MAX}
-                  </Text>
                 </View>
               </View>
 

--- a/frontend/app/(app)/incidents/view.tsx
+++ b/frontend/app/(app)/incidents/view.tsx
@@ -43,7 +43,9 @@ import {
   PackageSearch,
   Phone,
   ShieldAlert,
+  ShieldOff,
   Users,
+  Car,
 } from "lucide-react-native";
 
 type Role = "citizen" | "officer";
@@ -324,12 +326,26 @@ export default function ViewIncident() {
     );
   }
 
-  const catIcon = {
-    Safety: ShieldAlert,
-    Crime: AlertTriangle,
-    Maintenance: PackageSearch,
-    Other: Info,
-  }[report.category];
+  const categoryLabel = report.category?.trim?.() ? report.category : "Incident";
+  const categoryKey = categoryLabel.toLowerCase();
+  const catIcon = (() => {
+    if (categoryKey.includes("theft") || categoryKey.includes("steal")) {
+      return ShieldOff;
+    }
+    if (categoryKey.includes("hazard") || categoryKey.includes("danger")) {
+      return AlertTriangle;
+    }
+    if (categoryKey.includes("accident") || categoryKey.includes("crash") || categoryKey.includes("collision")) {
+      return Car;
+    }
+    if (categoryKey.includes("maint") || categoryKey.includes("repair")) {
+      return PackageSearch;
+    }
+    if (categoryKey.includes("crime")) {
+      return AlertTriangle;
+    }
+    return ShieldAlert;
+  })();
 
   const PillIcon = prioPill(priority).Icon;
 
@@ -406,7 +422,7 @@ export default function ViewIncident() {
             <View className="flex-row flex-wrap items-center gap-2">
               <View className="flex-row items-center gap-1 bg-background border border-border rounded-lg px-2 py-1">
                 {catIcon ? createElement(catIcon, { size: 14, color: "#0F172A" }) : <Info size={14} color="#0F172A" />}
-                <Text className="text-[12px] text-foreground">{report.category}</Text>
+                <Text className="text-[12px] text-foreground">{categoryLabel}</Text>
               </View>
               <View className="flex-row items-center gap-1 bg-background border border-border rounded-lg px-2 py-1">
                 <MapPin size={14} color="#0F172A" />


### PR DESCRIPTION
## Summary
- ensure My Reports only lists lost items submitted by the signed-in citizen and add quick links to start new incident or lost item reports
- parse stored incident descriptions to strip bracketed categories, carry the category metadata through API helpers, and show friendly icons in the incident view
- update the incident form to save the category as a labeled line and remove the descriptive hint/counter beneath the narrative field

## Testing
- npm run lint *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68e14b4d8924832a8d52e84ebb396c33