### PR TITLE
docs(frontend): standardize comments

### DIFF
--- a/frontend/app/(auth)/_layout.tsx
+++ b/frontend/app/(auth)/_layout.tsx
@@ -1,10 +1,7 @@
-// app/(auth)/_layout.tsx
 import { Stack } from "expo-router";
 
 /**
- * Auth group layout.
- * - Hosts authentication screens with no headers for a clean look.
- * - Keep options minimal; global providers live in the root layout.
+ * Authentication stack layout with headerless screens for login flows.
  */
 export default function AuthLayout() {
   return (

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,13 +1,10 @@
-// app/index.tsx
 import { router } from "expo-router";
 import { useEffect, useContext } from "react";
 import { ActivityIndicator, InteractionManager, View } from "react-native";
 import { AuthContext } from "@/context/AuthContext";
 
 /**
- * Initial splash/redirect screen.
- * - Waits for interactions to settle, then redirects to /login.
- * - Avoids navigating before the root layout has mounted.
+ * Landing screen that waits for initial interactions before routing to login or home.
  */
 export default function Index() {
   const { session } = useContext(AuthContext);

--- a/frontend/components/Collapsible.tsx
+++ b/frontend/components/Collapsible.tsx
@@ -7,6 +7,9 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
+/**
+ * Disclosure component used to tuck supporting information behind a toggleable header.
+ */
 export function Collapsible({ children, title }: PropsWithChildren & { title: string }) {
   const [isOpen, setIsOpen] = useState(false);
   const theme = useColorScheme() ?? 'light';

--- a/frontend/components/ExternalLink.tsx
+++ b/frontend/components/ExternalLink.tsx
@@ -3,8 +3,15 @@ import { openBrowserAsync } from 'expo-web-browser';
 import { type ComponentProps } from 'react';
 import { Platform } from 'react-native';
 
+/**
+ * Props for the external link wrapper that ensures consistent browser behavior across platforms.
+ */
 type Props = Omit<ComponentProps<typeof Link>, 'href'> & { href: Href & string };
 
+/**
+ * Renders a link that opens in the system browser on web and the in-app browser on native
+ * platforms to keep the navigation experience consistent.
+ */
 export function ExternalLink({ href, ...rest }: Props) {
   return (
     <Link
@@ -13,9 +20,8 @@ export function ExternalLink({ href, ...rest }: Props) {
       href={href}
       onPress={async (event) => {
         if (Platform.OS !== 'web') {
-          // Prevent the default behavior of linking to the default browser on native.
+          // Avoid handing control to the native browser so we can present the in-app experience.
           event.preventDefault();
-          // Open the link in an in-app browser.
           await openBrowserAsync(href);
         }
       }}

--- a/frontend/components/HapticTab.tsx
+++ b/frontend/components/HapticTab.tsx
@@ -2,13 +2,16 @@ import { BottomTabBarButtonProps } from '@react-navigation/bottom-tabs';
 import { PlatformPressable } from '@react-navigation/elements';
 import * as Haptics from 'expo-haptics';
 
+/**
+ * Tab bar button that adds a light haptic response on iOS to reinforce navigation feedback.
+ */
 export function HapticTab(props: BottomTabBarButtonProps) {
   return (
     <PlatformPressable
       {...props}
       onPressIn={(ev) => {
         if (process.env.EXPO_OS === 'ios') {
-          // Add a soft haptic feedback when pressing down on the tabs.
+          // Provide a gentle cue to signal the press was registered.
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         }
         props.onPressIn?.(ev);

--- a/frontend/components/HelloWave.tsx
+++ b/frontend/components/HelloWave.tsx
@@ -10,13 +10,16 @@ import Animated, {
 
 import { ThemedText } from '@/components/ThemedText';
 
+/**
+ * Animated waving emoji used as a friendly accent on onboarding screens.
+ */
 export function HelloWave() {
   const rotationAnimation = useSharedValue(0);
 
   useEffect(() => {
     rotationAnimation.value = withRepeat(
       withSequence(withTiming(25, { duration: 150 }), withTiming(0, { duration: 150 })),
-      4 // Run the animation 4 times
+      4, // Repeat a short wave for a welcoming feel.
     );
   }, [rotationAnimation]);
 

--- a/frontend/components/ParallaxScrollView.tsx
+++ b/frontend/components/ParallaxScrollView.tsx
@@ -13,11 +13,17 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 
 const HEADER_HEIGHT = 250;
 
+/**
+ * Props for the parallax scroll view, including the header illustration and theme-aware colors.
+ */
 type Props = PropsWithChildren<{
   headerImage: ReactElement;
   headerBackgroundColor: { dark: string; light: string };
 }>;
 
+/**
+ * Scroll view that provides a simple parallax header while respecting the bottom tab offset.
+ */
 export default function ParallaxScrollView({
   children,
   headerImage,

--- a/frontend/components/ThemedText.tsx
+++ b/frontend/components/ThemedText.tsx
@@ -2,12 +2,19 @@ import { StyleSheet, Text, type TextProps } from 'react-native';
 
 import { useThemeColor } from '@/hooks/useThemeColor';
 
+/**
+ * Props for themed text, allowing the caller to override the colors and typography style.
+ */
 export type ThemedTextProps = TextProps & {
   lightColor?: string;
   darkColor?: string;
   type?: 'default' | 'title' | 'defaultSemiBold' | 'subtitle' | 'link';
 };
 
+/**
+ * Renders text that automatically adapts to the active theme palette while supporting
+ * a curated set of typography variants for consistent presentation.
+ */
 export function ThemedText({
   style,
   lightColor,

--- a/frontend/components/ThemedView.tsx
+++ b/frontend/components/ThemedView.tsx
@@ -2,11 +2,17 @@ import { View, type ViewProps } from 'react-native';
 
 import { useThemeColor } from '@/hooks/useThemeColor';
 
+/**
+ * Props for theme-aware views, allowing background color overrides per scheme.
+ */
 export type ThemedViewProps = ViewProps & {
   lightColor?: string;
   darkColor?: string;
 };
 
+/**
+ * Wrapper around React Native's View that automatically adapts its background to the active theme.
+ */
 export function ThemedView({ style, lightColor, darkColor, ...otherProps }: ThemedViewProps) {
   const backgroundColor = useThemeColor({ light: lightColor, dark: darkColor }, 'background');
 

--- a/frontend/components/app/shell.tsx
+++ b/frontend/components/app/shell.tsx
@@ -15,6 +15,9 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { ChevronLeft } from "lucide-react-native";
 import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 
+/**
+ * Props for the shared app screen wrapper.
+ */
 type AppScreenProps = {
   children: ReactNode;
   scroll?: boolean;
@@ -27,8 +30,8 @@ type AppScreenProps = {
 };
 
 /**
- * Shared atmospheric wrapper for app screens.
- * Adds a soft backdrop, consistent padding, and optional floating action area.
+ * Provides a consistent layout shell with responsive padding, scroll behaviour, and optional
+ * floating action slot.
  */
 export function AppScreen({
   children,
@@ -106,12 +109,15 @@ export function AppScreen({
   );
 }
 
+/**
+ * Props for the atmospheric card surface.
+ */
 type AppCardProps = ViewProps & {
   translucent?: boolean;
 };
 
 /**
- * Frosted card surface with rounded corners and subtle drop shadow.
+ * Frosted card surface with rounded corners and subtle shadow for dashboard content.
  */
 export const AppCard = forwardRef<View, AppCardProps>(
   ({ className, style, translucent = false, ...props }, ref) => {
@@ -131,6 +137,9 @@ export const AppCard = forwardRef<View, AppCardProps>(
 );
 AppCard.displayName = "AppCard";
 
+/**
+ * Props for section headers inside the dashboard shell.
+ */
 type SectionHeaderProps = {
   eyebrow?: string;
   title: string;
@@ -139,7 +148,7 @@ type SectionHeaderProps = {
 };
 
 /**
- * Standardised section heading with optional eyebrow and trailing action.
+ * Standardised section heading with optional eyebrow and trailing action slot.
  */
 export function SectionHeader({ eyebrow, title, description, trailing }: SectionHeaderProps) {
   return (
@@ -164,6 +173,9 @@ export function SectionHeader({ eyebrow, title, description, trailing }: Section
   );
 }
 
+/**
+ * Props for the pill badge component.
+ */
 type PillProps = ViewProps & {
   tone?: "primary" | "accent" | "neutral" | "danger";
   icon?: ComponentType<{ size?: number; color?: string }>;
@@ -171,7 +183,7 @@ type PillProps = ViewProps & {
 };
 
 /**
- * Compact pill badge for statuses/counts.
+ * Compact pill badge for summarising counts or statuses alongside metadata.
  */
 export function Pill({ tone = "neutral", icon: Icon, label, className, style, ...props }: PillProps) {
   const palette = PILL_TONES[tone] ?? PILL_TONES.neutral;
@@ -196,6 +208,9 @@ const PILL_TONES = {
   danger: { bg: "#FEE2E2", fg: "#B91C1C" },
 } as const;
 
+/**
+ * Props for the soft navigation header.
+ */
 type ScreenHeaderProps = {
   title: string;
   subtitle?: string;
@@ -205,7 +220,7 @@ type ScreenHeaderProps = {
 };
 
 /**
- * Soft navigation header with optional back button and trailing action.
+ * Soft navigation header with optional back button, icon, and trailing action area.
  */
 export function ScreenHeader({ title, subtitle, icon: Icon, onBack, action }: ScreenHeaderProps) {
   return (

--- a/frontend/components/map/MapboxLocationPicker.tsx
+++ b/frontend/components/map/MapboxLocationPicker.tsx
@@ -714,6 +714,9 @@ function MapboxLocationModal({ visible, initialLocation, onSelect, onRequestClos
   );
 }
 
+/**
+ * Form field wrapper for selecting and previewing a Mapbox location with static map imagery.
+ */
 export function MapboxLocationField({
   label = "Location",
   value,

--- a/frontend/components/toast.tsx
+++ b/frontend/components/toast.tsx
@@ -8,13 +8,19 @@ type ToastData = {
   title?: string;
   message: string;
   variant?: Variant;
-  duration?: number; // ms
+  /** Duration in milliseconds before the toast auto-dismisses. */
+  duration?: number;
 };
 
-// Simple pub/sub so you can call toast.success(...) from anywhere
+/**
+ * Simple publish/subscribe bus for toast notifications so any module can trigger feedback.
+ */
 let subs = new Set<(t: ToastData) => void>();
 let _id = 0;
 
+/**
+ * Convenience helpers for dispatching toast messages with sensible defaults.
+ */
 export const toast = {
   show(opts: Omit<ToastData, "id">) {
     const t: ToastData = { id: ++_id, duration: 2500, variant: "info", ...opts };
@@ -31,6 +37,9 @@ export const toast = {
   },
 };
 
+/**
+ * Overlay component that renders the active toast queue.
+ */
 export function ToastOverlay() {
   const [items, setItems] = useState<ToastData[]>([]);
 

--- a/frontend/components/ui/IconSymbol.ios.tsx
+++ b/frontend/components/ui/IconSymbol.ios.tsx
@@ -1,6 +1,9 @@
 import { SymbolView, SymbolViewProps, SymbolWeight } from 'expo-symbols';
 import { StyleProp, ViewStyle } from 'react-native';
 
+/**
+ * iOS-specific icon renderer that leverages SF Symbols for native fidelity.
+ */
 export function IconSymbol({
   name,
   size = 24,

--- a/frontend/components/ui/IconSymbol.tsx
+++ b/frontend/components/ui/IconSymbol.tsx
@@ -1,5 +1,3 @@
-// Fallback for using MaterialIcons on Android and web.
-
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { SymbolWeight, SymbolViewProps } from 'expo-symbols';
 import { ComponentProps } from 'react';
@@ -9,9 +7,7 @@ type IconMapping = Record<SymbolViewProps['name'], ComponentProps<typeof Materia
 type IconSymbolName = keyof typeof MAPPING;
 
 /**
- * Add your SF Symbols to Material Icons mappings here.
- * - see Material Icons in the [Icons Directory](https://icons.expo.fyi).
- * - see SF Symbols in the [SF Symbols](https://developer.apple.com/sf-symbols/) app.
+ * Cross-platform mapping from SF Symbol identifiers to Material Icons for non-iOS platforms.
  */
 const MAPPING = {
   'house.fill': 'home',
@@ -21,9 +17,8 @@ const MAPPING = {
 } as IconMapping;
 
 /**
- * An icon component that uses native SF Symbols on iOS, and Material Icons on Android and web.
- * This ensures a consistent look across platforms, and optimal resource usage.
- * Icon `name`s are based on SF Symbols and require manual mapping to Material Icons.
+ * Icon component that renders SF Symbols on iOS and Material Icons elsewhere, keeping iconography
+ * consistent across platforms.
  */
 export function IconSymbol({
   name,

--- a/frontend/components/ui/TabBarBackground.ios.tsx
+++ b/frontend/components/ui/TabBarBackground.ios.tsx
@@ -2,11 +2,13 @@ import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { BlurView } from 'expo-blur';
 import { StyleSheet } from 'react-native';
 
+/**
+ * iOS tab bar background that uses system materials to mirror native appearance.
+ */
 export default function BlurTabBarBackground() {
   return (
     <BlurView
-      // System chrome material automatically adapts to the system's theme
-      // and matches the native tab bar appearance on iOS.
+      // System chrome material adapts to the active theme to match native chrome.
       tint="systemChromeMaterial"
       intensity={100}
       style={StyleSheet.absoluteFill}
@@ -14,6 +16,9 @@ export default function BlurTabBarBackground() {
   );
 }
 
+/**
+ * Accounts for the translucent iOS tab bar so scroll views leave enough padding.
+ */
 export function useBottomTabOverflow() {
   return useBottomTabBarHeight();
 }

--- a/frontend/components/ui/TabBarBackground.tsx
+++ b/frontend/components/ui/TabBarBackground.tsx
@@ -1,6 +1,8 @@
-// This is a shim for web and Android where the tab bar is generally opaque.
 export default undefined;
 
+/**
+ * No-op hook on web and Android because the tab bar does not overlap scroll content.
+ */
 export function useBottomTabOverflow() {
   return 0;
 }

--- a/frontend/components/ui/button.tsx
+++ b/frontend/components/ui/button.tsx
@@ -4,6 +4,9 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { Platform, Pressable } from 'react-native';
 import type { ComponentProps, RefAttributes } from 'react';
 
+/**
+ * Tailwind class variants for the Guardian button component.
+ */
 const buttonVariants = cva(
   cn(
     'group shrink-0 flex-row items-center justify-center gap-2 rounded-md shadow-none',
@@ -54,6 +57,9 @@ const buttonVariants = cva(
   }
 );
 
+/**
+ * Text styling variants that keep button copy aligned with the surface state.
+ */
 const buttonTextVariants = cva(
   cn(
     'text-foreground text-sm font-medium',
@@ -89,10 +95,16 @@ const buttonTextVariants = cva(
   }
 );
 
+/**
+ * Props accepted by the Guardian button component.
+ */
 type ButtonProps = ComponentProps<typeof Pressable> &
   RefAttributes<typeof Pressable> &
   VariantProps<typeof buttonVariants>;
 
+/**
+ * Accessible pressable surface that supports multiple visual variants and auto styled text.
+ */
 function Button({ className, variant, size, ...props }: ButtonProps) {
   return (
     <TextClassContext.Provider value={buttonTextVariants({ variant, size })}>

--- a/frontend/components/ui/icon.tsx
+++ b/frontend/components/ui/icon.tsx
@@ -21,24 +21,7 @@ cssInterop(IconImpl, {
 });
 
 /**
- * A wrapper component for Lucide icons with Nativewind `className` support via `cssInterop`.
- *
- * This component allows you to render any Lucide icon while applying utility classes
- * using `nativewind`. It avoids the need to wrap or configure each icon individually.
- *
- * @component
- * @example
- * ```tsx
- * import { ArrowRight } from 'lucide-react-native';
- * import { Icon } from '@/registry/components/ui/icon';
- *
- * <Icon as={ArrowRight} className="text-red-500" size={16} />
- * ```
- *
- * @param {LucideIcon} as - The Lucide icon component to render.
- * @param {string} className - Utility classes to style the icon using Nativewind.
- * @param {number} size - Icon size (defaults to 14).
- * @param {...LucideProps} ...props - Additional Lucide icon props passed to the "as" icon.
+ * Wrapper for Lucide icons that enables NativeWind className support without manual configuration.
  */
 function Icon({ as: IconComponent, className, size = 14, ...props }: IconProps) {
   return (

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -2,6 +2,9 @@ import { cn } from '@/lib/utils';
 import { Platform, TextInput, type TextInputProps } from 'react-native';
 import type { RefAttributes } from 'react';
 
+/**
+ * Text input styled to match Guardian surface tones across platforms.
+ */
 function Input({
   className,
   placeholderClassName,

--- a/frontend/components/ui/label.tsx
+++ b/frontend/components/ui/label.tsx
@@ -3,6 +3,9 @@ import * as LabelPrimitive from '@rn-primitives/label';
 import { Platform } from 'react-native';
 import type { RefAttributes } from 'react';
 
+/**
+ * Accessible form label that pairs touch handlers with consistent typography.
+ */
 function Label({
   className,
   onPress,

--- a/frontend/components/ui/text.tsx
+++ b/frontend/components/ui/text.tsx
@@ -67,8 +67,14 @@ const ARIA_LEVEL: Partial<Record<TextVariant, string>> = {
   h4: '4',
 };
 
+/**
+ * Context used to cascade typography classes into nested text elements (e.g. buttons).
+ */
 const TextClassContext = createContext<string | undefined>(undefined);
 
+/**
+ * Typography component that normalises text styles and exposes semantic variants across platforms.
+ */
 function Text({
   className,
   asChild = false,

--- a/frontend/context/AuthContext.tsx
+++ b/frontend/context/AuthContext.tsx
@@ -10,6 +10,9 @@ import { fetchProfile, type Profile } from '@/lib/api';
 import { useStorageState } from '@/hooks/useStorageState';
 import { apiService } from '@/services/apiService';
 
+/**
+ * Response payload shape returned by the refresh endpoint.
+ */
 interface RefreshResponse {
   data: {
     accessToken: string;
@@ -17,6 +20,9 @@ interface RefreshResponse {
   };
 }
 
+/**
+ * Public surface area of the authentication context, exposing session data and lifecycle helpers.
+ */
 interface IAuthContext {
   session: string | null;
   profile: Profile | null;
@@ -41,6 +47,9 @@ export const AuthContext = createContext<IAuthContext>({
   refreshProfile: async () => null,
 });
 
+/**
+ * Verifies whether the server still considers the stored access token valid.
+ */
 async function accessTokenIsValid(): Promise<boolean> {
   try {
     const request = await apiService.get('/api/v1/auth/is-authed');
@@ -50,6 +59,10 @@ async function accessTokenIsValid(): Promise<boolean> {
   }
 }
 
+/**
+ * Provides authentication state to the application, handling token storage, refresh lifecycles,
+ * and profile hydration so screens can rely on a consistent session view.
+ */
 export function AuthProvider({ children }: PropsWithChildren) {
   const [[isLoadingAccess, accessTokenSession], setAccessTokenSession] =
     useStorageState('accessToken');

--- a/frontend/hooks/useColorScheme.web.ts
+++ b/frontend/hooks/useColorScheme.web.ts
@@ -2,7 +2,8 @@ import { useEffect, useState } from 'react';
 import { useColorScheme as useRNColorScheme } from 'react-native';
 
 /**
- * To support static rendering, this value needs to be re-calculated on the client side for web
+ * Web-specific color scheme hook that waits for hydration before trusting the system preference
+ * so static renders default to light mode and avoid mismatches.
  */
 export function useColorScheme() {
   const [hasHydrated, setHasHydrated] = useState(false);

--- a/frontend/hooks/useMountAnimation.ts
+++ b/frontend/hooks/useMountAnimation.ts
@@ -1,6 +1,10 @@
 import { useEffect, useRef } from "react";
 import { Animated } from "react-native";
 
+/**
+ * Provides a simple spring entrance animation for mounting components, returning the animated
+ * value and style helpers for convenience.
+ */
 export function useMountAnimation(config: Partial<Animated.SpringAnimationConfig> = {}) {
   const value = useRef(new Animated.Value(0.9)).current;
 

--- a/frontend/hooks/useResponsiveLayout.ts
+++ b/frontend/hooks/useResponsiveLayout.ts
@@ -1,6 +1,9 @@
 import { useMemo } from "react";
 import { useWindowDimensions } from "react-native";
 
+/**
+ * Calculated layout heuristics that help components adapt spacing to various device widths.
+ */
 export type ResponsiveLayout = {
   width: number;
   isCompact: boolean;
@@ -12,6 +15,10 @@ export type ResponsiveLayout = {
   maxContentWidth: number;
 };
 
+/**
+ * Derives responsive layout metrics from the current window dimensions to keep spacing consistent
+ * across small and large screens.
+ */
 export function useResponsiveLayout(): ResponsiveLayout {
   const { width } = useWindowDimensions();
 

--- a/frontend/hooks/useStorageState.ts
+++ b/frontend/hooks/useStorageState.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import * as SecureStore from 'expo-secure-store';
 
+/**
+ * Persists a value in secure storage while exposing loading state so screens can defer rendering
+ * until the initial read resolves.
+ */
 export function useStorageState(key: string) {
   const [isLoading, setIsLoading] = useState(true);
   const [value, setValue] = useState<string | null>(null);

--- a/frontend/hooks/useThemeColor.ts
+++ b/frontend/hooks/useThemeColor.ts
@@ -1,11 +1,10 @@
-/**
- * Learn more about light and dark modes:
- * https://docs.expo.dev/guides/color-schemes/
- */
-
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 
+/**
+ * Resolves a color token that respects the active system theme while allowing callers to
+ * provide explicit light and dark overrides when necessary.
+ */
 export function useThemeColor(
   props: { light?: string; dark?: string },
   colorName: keyof typeof Colors.light & keyof typeof Colors.dark

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -81,6 +81,9 @@ function formatRelative(date: string | null | undefined): string {
   return parsed.toLocaleDateString();
 }
 
+/**
+ * Formats a timestamp into a short relative string so timelines stay readable at a glance.
+ */
 export function formatRelativeTime(
   date: string | null | undefined,
 ): string {
@@ -160,6 +163,9 @@ function toNumberOrNull(value: unknown): number | null {
   return null;
 }
 
+/**
+ * Retrieves the signed Mapbox access token for map rendering and throws if none is configured.
+ */
 export async function fetchMapboxToken(): Promise<string> {
   const data = await unwrap<any>(
     apiService.get<ApiEnvelope<any>>("/api/v1/map-box/token"),
@@ -198,6 +204,9 @@ export type Profile = {
   isOfficer: boolean;
 };
 
+/**
+ * Loads the authenticated user's profile and normalises fields for the app.
+ */
 export async function fetchProfile(): Promise<Profile> {
   const data = await unwrap<any>(
     apiService.get<ApiEnvelope<any>>("/api/v1/auth/profile"),
@@ -236,6 +245,9 @@ export type AlertRow = {
   createdAt?: string | null;
 };
 
+/**
+ * Fetches the list of broadcast alerts for the active role and adapts the payload for UI use.
+ */
 export async function fetchAlerts(): Promise<AlertRow[]> {
   const data = await unwrap<any[]>(
     apiService.get<ApiEnvelope<any[]>>("/api/v1/alerts"),
@@ -249,6 +261,9 @@ export async function fetchAlerts(): Promise<AlertRow[]> {
   }));
 }
 
+/**
+ * Loads a single alert so edit flows can pre-fill the form with the latest details.
+ */
 export async function getAlert(id: string): Promise<AlertRow> {
   const data = await unwrap<any>(
     apiService.get<ApiEnvelope<any>>(`/api/v1/alerts/${id}`),
@@ -262,6 +277,9 @@ export async function getAlert(id: string): Promise<AlertRow> {
   };
 }
 
+/**
+ * Creates or updates an alert based on whether an identifier is present, returning the saved row.
+ */
 export async function saveAlert(data: AlertDraft): Promise<AlertRow> {
   const payload = {
     title: data.title,
@@ -281,6 +299,9 @@ export async function saveAlert(data: AlertDraft): Promise<AlertRow> {
   };
 }
 
+/**
+ * Removes an alert from the server so it no longer appears in dashboard listings.
+ */
 export async function deleteAlert(id: string): Promise<void> {
   await apiService.delete(`/api/v1/alerts/${id}`);
 }
@@ -425,6 +446,9 @@ function mapReportWitness(data: any): ReportWitness {
   };
 }
 
+/**
+ * Submits a new incident report including optional media, returning a summary for list views.
+ */
 export async function createReport(
   payload: CreateReportPayload,
 ): Promise<ReportSummary> {
@@ -478,6 +502,9 @@ export async function createReport(
   };
 }
 
+/**
+ * Adds a witness to an incident report and returns the newly created record.
+ */
 export async function createReportWitness(
   reportId: string,
   payload: ReportWitnessPayload,
@@ -496,6 +523,9 @@ export async function createReportWitness(
   return mapReportWitness(data);
 }
 
+/**
+ * Retrieves all incident reports, mapping backend payloads into concise dashboard summaries.
+ */
 export async function fetchReports(): Promise<ReportSummary[]> {
   const data = await unwrap<any[]>(
     apiService.get<ApiEnvelope<any[]>>("/api/v1/reports"),
@@ -521,6 +551,9 @@ export async function fetchReports(): Promise<ReportSummary[]> {
   });
 }
 
+/**
+ * Loads chronological notes for a specific report to power the case activity feed.
+ */
 export async function fetchReportNotes(id: string): Promise<Note[]> {
   const data = await unwrap<any[]>(
     apiService.get<ApiEnvelope<any[]>>(`/api/v1/notes/resource/${id}`, {
@@ -530,6 +563,9 @@ export async function fetchReportNotes(id: string): Promise<Note[]> {
   return (Array.isArray(data) ? data : []).map(mapNote);
 }
 
+/**
+ * Retrieves a full incident record including notes, witnesses, and location metadata.
+ */
 export async function getIncident(id: string): Promise<Report> {
   const [report, notes] = await Promise.all([
     unwrap<any>(apiService.get<ApiEnvelope<any>>(`/api/v1/reports/${id}`)),
@@ -579,6 +615,9 @@ export async function getIncident(id: string): Promise<Report> {
   };
 }
 
+/**
+ * Updates the backend status for an incident so officers can progress the workflow.
+ */
 export async function updateReportStatus(
   id: string,
   status: FrontendReportStatus,
@@ -590,6 +629,9 @@ export async function updateReportStatus(
   );
 }
 
+/**
+ * Appends a note to an incident report and returns the new entry for activity timelines.
+ */
 export async function addReportNote(
   reportId: string,
   subject: string,
@@ -688,6 +730,9 @@ export type LostItemPayload = {
   status?: "PENDING" | "INVESTIGATING" | "FOUND" | "CLOSED";
 };
 
+/**
+ * Retrieves items marked as found so citizens can review recent matches.
+ */
 export async function fetchFoundItems(): Promise<FoundItem[]> {
   const data = await unwrap<any[]>(
     apiService.get<ApiEnvelope<any[]>>("/api/v1/lost-articles/all"),
@@ -734,6 +779,9 @@ function mapLostItemDetail(item: any): LostItemDetail {
   };
 }
 
+/**
+ * Loads the public view of a found item for citizen detail screens.
+ */
 export async function getFoundItem(id: string): Promise<FoundItemDetail> {
   const data = await unwrap<any>(
     apiService.get<ApiEnvelope<any>>(`/api/v1/lost-articles/${id}`),
@@ -741,6 +789,9 @@ export async function getFoundItem(id: string): Promise<FoundItemDetail> {
   return mapLostItem(data);
 }
 
+/**
+ * Retrieves an officer-facing lost item record with private metadata.
+ */
 export async function getLostItem(id: string): Promise<LostItemDetail> {
   const data = await unwrap<any>(
     apiService.get<ApiEnvelope<any>>(`/api/v1/lost-articles/${id}`),
@@ -748,6 +799,9 @@ export async function getLostItem(id: string): Promise<LostItemDetail> {
   return mapLostItemDetail(data);
 }
 
+/**
+ * Submits a new lost item report from a citizen, including location context for follow-up.
+ */
 export async function reportLostItem(payload: LostItemPayload): Promise<void> {
   const form = new FormData();
   form.append("name", payload.itemName);
@@ -767,6 +821,9 @@ export async function reportLostItem(payload: LostItemPayload): Promise<void> {
   );
 }
 
+/**
+ * Retrieves the officer-facing lost item catalogue for operational review.
+ */
 export async function fetchLostItems(): Promise<LostItemDetail[]> {
   const data = await unwrap<any[]>(
     apiService.get<ApiEnvelope<any[]>>("/api/v1/lost-articles/all"),
@@ -801,6 +858,9 @@ function toLostItemUpdateBody(payload: Partial<LostItemUpdatePayload>) {
   return body;
 }
 
+/**
+ * Applies partial updates to a lost item record from the officer console.
+ */
 export async function updateLostItem(
   id: string,
   payload: Partial<LostItemUpdatePayload>,
@@ -812,6 +872,9 @@ export async function updateLostItem(
   return mapLostItemDetail(data);
 }
 
+/**
+ * Updates the workflow status for a lost item, ensuring officer actions stay in sync.
+ */
 export async function updateLostItemStatus(
   id: string,
   status: LostFrontendStatus,
@@ -824,6 +887,9 @@ export async function updateLostItemStatus(
   return mapLostItemDetail(data);
 }
 
+/**
+ * Retrieves officer notes attached to a lost item for audit history.
+ */
 export async function fetchLostItemNotes(id: string): Promise<ItemNote[]> {
   const data = await unwrap<any[]>(
     apiService.get<ApiEnvelope<any[]>>(`/api/v1/notes/resource/${id}`, {
@@ -833,6 +899,9 @@ export async function fetchLostItemNotes(id: string): Promise<ItemNote[]> {
   return (Array.isArray(data) ? data : []).map(mapNote);
 }
 
+/**
+ * Adds an officer note to a lost item and returns the enriched entry for display.
+ */
 export async function addLostItemNote(
   id: string,
   subject: string,
@@ -861,6 +930,9 @@ export type FoundItemPostPayload = {
   status?: LostFrontendStatus;
 };
 
+/**
+ * Allows officers to publish a found item so citizens can reclaim their belongings.
+ */
 export async function createFoundItem(
   payload: FoundItemPostPayload,
 ): Promise<LostItemDetail> {

--- a/frontend/lib/mapbox.ts
+++ b/frontend/lib/mapbox.ts
@@ -9,6 +9,9 @@ export type MapboxLocation = {
 const DEFAULT_LATITUDE = 6.9271; // Colombo, Sri Lanka latitude
 const DEFAULT_LONGITUDE = 79.8612; // Colombo, Sri Lanka longitude
 
+/**
+ * Default map center used when no coordinates are available from the backend.
+ */
 export const DEFAULT_MAPBOX_CENTER: MapboxLocation = {
   latitude: DEFAULT_LATITUDE,
   longitude: DEFAULT_LONGITUDE,
@@ -17,6 +20,9 @@ export const DEFAULT_MAPBOX_CENTER: MapboxLocation = {
 let cachedToken: string | null = null;
 let pendingToken: Promise<string> | null = null;
 
+/**
+ * Provides a cached Mapbox access token, avoiding duplicate network requests across screens.
+ */
 export async function getMapboxAccessToken(): Promise<string> {
   if (cachedToken) {
     return cachedToken;
@@ -37,12 +43,18 @@ export async function getMapboxAccessToken(): Promise<string> {
   return pendingToken;
 }
 
+/**
+ * Formats a latitude and longitude into a compact human-readable string.
+ */
 export function formatCoordinates(latitude: number, longitude: number): string {
   const lat = Number.isFinite(latitude) ? latitude.toFixed(4) : "0";
   const lon = Number.isFinite(longitude) ? longitude.toFixed(4) : "0";
   return `Lat ${lat}, Lon ${lon}`;
 }
 
+/**
+ * Reverse geocodes a coordinate to a friendly place label, optionally using a provided token.
+ */
 export async function reverseGeocodeLocation(
   latitude: number,
   longitude: number,
@@ -82,6 +94,9 @@ function clampDimension(value: number, fallback: number): number {
   return Math.max(64, Math.min(1280, rounded));
 }
 
+/**
+ * Builds a static Mapbox image URL for previewing a location pin within forms.
+ */
 export function buildStaticMapPreviewUrl(
   latitude: number,
   longitude: number,
@@ -130,6 +145,9 @@ export type MapboxSearchResult = MapboxLocation & {
   description?: string;
 };
 
+/**
+ * Queries the Mapbox geocoding API for suggested places, supporting proximity and country hints.
+ */
 export async function searchMapboxLocations(
   query: string,
   options?: {

--- a/frontend/lib/utils.ts
+++ b/frontend/lib/utils.ts
@@ -1,6 +1,9 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
+/**
+ * Utility to merge Tailwind class names while removing duplicates and handling conditional values.
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }

--- a/frontend/services/apiService.ts
+++ b/frontend/services/apiService.ts
@@ -1,6 +1,9 @@
 import axios from 'axios';
 import * as SecureStore from 'expo-secure-store';
 
+/**
+ * Shared Axios instance configured with Guardian defaults including base URL and token interceptors.
+ */
 export const apiService = axios.create({
   baseURL: process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:2699',
 });


### PR DESCRIPTION
## Summary
- add consistent JSDoc headers and context to shared frontend components and utilities
- document authentication context, hooks, and API helpers for clearer intent
- refresh comments across app shell and map tooling to highlight dashboard connectivity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e35442c790832aa06ab9cc67f7d55e