### PR TITLE
Import HttpError in personal details service

### DIFF
--- a/backend/src/services/personal-details.service.js
+++ b/backend/src/services/personal-details.service.js
@@ -1,5 +1,6 @@
 const z = require("zod");
 const PersonalDetailsModel = require("../models/personal-details.model");
+const HttpError = require("../utils/http-error");
 
 class PersonalDetailsService {
   PersonalDetailsValidation = z.object({


### PR DESCRIPTION
## Summary
- import the HttpError utility into the personal details service so thrown errors resolve correctly

## Testing
- `NODE_ENV=test node -e "require('./backend/src/services/personal-details.service'); console.log('loaded');"`


------
https://chatgpt.com/codex/tasks/task_e_68e3632686bc832aa1902a3bbaa19adc