### PR TITLE
Fix deletion flows and logout handling

### DIFF
--- a/backend/src/routes/lost-articles.route.js
+++ b/backend/src/routes/lost-articles.route.js
@@ -13,7 +13,7 @@ lostArticlesRouter.post(
 );
 
 lostArticlesRouter.delete(
-  "/lostArticleId",
+  "/:lostArticleId",
   OfficerAuthenticationMiddleware,
   lostArticlesControler.delete,
 );
@@ -26,7 +26,7 @@ lostArticlesRouter.post(
 lostArticlesRouter.delete(
   "/personal-details/:lostArticleId/:personalDetailsId",
   OfficerAuthenticationMiddleware,
-  lostArticlesControler.createPersonalDetails,
+  lostArticlesControler.deletePersonalDetails,
 );
 
 lostArticlesRouter.get("/all", lostArticlesControler.getAll);

--- a/backend/src/services/notes.service.js
+++ b/backend/src/services/notes.service.js
@@ -7,7 +7,7 @@ class NotesService {
     subject: z.string(),
     content: z.string(),
     resource_id: z.preprocess((val) => Number(val), z.number()).optional(),
-    resource_type: z.literal(["report", "lost-article"]),
+    resource_type: z.enum(["report", "lost-article"]),
   });
 
   noteUpdateValidation = z.object({
@@ -17,7 +17,7 @@ class NotesService {
 
   resourceGetPropertiesValidation = z.object({
     resourceId: z.preprocess((val) => Number(val), z.number()).optional(),
-    resourceType: z.literal(["report", "lost-article"]),
+    resourceType: z.enum(["report", "lost-article"]),
     userId: z.number(),
     officer: z.boolean().optional(),
   });

--- a/backend/src/services/personal-details.service.js
+++ b/backend/src/services/personal-details.service.js
@@ -1,5 +1,6 @@
 const z = require("zod");
 const PersonalDetailsModel = require("../models/personal-details.model");
+const HttpError = require("../utils/http-error");
 
 class PersonalDetailsService {
   PersonalDetailsValidation = z.object({

--- a/frontend/app/(app)/home.tsx
+++ b/frontend/app/(app)/home.tsx
@@ -99,6 +99,7 @@ export default function Home() {
     profile,
     profileLoading,
     refreshProfile,
+    logout,
   } = useContext(AuthContext);
   const layout = useResponsiveLayout();
 
@@ -299,7 +300,10 @@ export default function Home() {
     });
   }, [session, refreshProfile, loadDashboardData]);
 
-  const onSignOut = () => router.replace('/login');
+  const onSignOut = useCallback(async () => {
+    await logout();
+    router.replace('/login');
+  }, [logout]);
 
   useEffect(() => {
     if (profile || profileLoading) return;


### PR DESCRIPTION
## Summary
- import the HttpError helper in the personal details service so witness deletions can throw correctly
- fix lost article routes and notes validation to accept the correct resource type variants
- clear auth state through the context before redirecting from the dashboard sign-out button

## Testing
- npm test -- notes

------
https://chatgpt.com/codex/tasks/task_e_68e35fb1e97c832a90fbcce1b061d9bb