### PR TITLE
Integrate Kommunicate widget into dashboard

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,10 +3,10 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
-    "dev": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c",
-    "android": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --android",
-    "ios": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --ios",
-    "web": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --web",
+    "dev": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 EXPO_PUBLIC_KOMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 expo start -c",
+    "android": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 EXPO_PUBLIC_KOMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 expo start -c --android",
+    "ios": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 EXPO_PUBLIC_KOMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 expo start -c --ios",
+    "web": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 EXPO_PUBLIC_KOMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 expo start -c --web",
     "clean": "rm -rf .expo node_modules"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- expose the Kommunicate App ID to Expo by wiring it into the existing scripts
- replace the placeholder chatbot form with a Kommunicate-powered WebView widget on the citizen dashboard
- pass authenticated user details to Kommunicate and surface a helpful message when the App ID is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3813d827c832a9ba8e17d57cb31a0