### PR TITLE
Add fallback Kommunicate app id

### DIFF
--- a/frontend/app/(app)/home.tsx
+++ b/frontend/app/(app)/home.tsx
@@ -283,6 +283,7 @@ export default function Home() {
     const candidates = [
       process.env.EXPO_PUBLIC_KOMMUNICATE_APP_ID,
       process.env.EXPO_PUBLIC_COMMUNICATE_APP_ID,
+      '1bc1af724f54a2ea777cb03d818d6a3a0',
     ];
     const match = candidates.find((value) => typeof value === 'string' && value.trim().length > 0);
     return match?.trim();


### PR DESCRIPTION
## Summary
- add a default Kommunicate app id so the chatbot loads when env vars are missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3a7a93d24832a9b9a75e605890736