### PR TITLE
Fix Kommunicate widget API selection

### DIFF
--- a/frontend/app/(app)/home.tsx
+++ b/frontend/app/(app)/home.tsx
@@ -1093,7 +1093,7 @@ const ChatbotWidget: FC<{
           var s = document.createElement("script"); s.type = "text/javascript"; s.async = true;
           s.src = "https://widget.kommunicate.io/v2/kommunicate.app";
           s.onload = function(){
-            var api = window.kommunicate || window.Kommunicate;
+            const api = window.Kommunicate || window.kommunicate;
             if (api && typeof api.displayKommunicateWidget === "function") {
               api.displayKommunicateWidget();
             } else if (api && typeof api.display === "function") {
@@ -1106,7 +1106,7 @@ const ChatbotWidget: FC<{
           var h = document.getElementsByTagName("head")[0]; h.appendChild(s);
           window.kommunicate = m; m._globals = kommunicateSettings;
           function ensureConversation(){
-            var api = window.kommunicate || window.Kommunicate;
+            const api = window.Kommunicate || window.kommunicate;
             if (api && typeof api.launchConversation === "function") {
               if (typeof api.displayKommunicateWidget === "function") {
                 api.displayKommunicateWidget();

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2979,7 +2979,7 @@
       "version": "19.0.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.14.tgz",
       "integrity": "sha512-ixLZ7zG7j1fM0DijL9hDArwhwcCb4vqmePgwtV0GfnkHRSCUEv4LvzarcTdhoqgyMznUx/EhoTUv31CKZzkQlw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -4309,7 +4309,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",


### PR DESCRIPTION
## Summary
- prefer the `window.Kommunicate` global when bootstrapping the webview widget so functions resolve correctly
- keep launching and display calls intact while ensuring the same API is used when retrying
- update lockfile metadata after reinstalling frontend dependencies

## Testing
- `npm install`
- `npm run start` *(fails: Expo CLI cannot fetch native module versions due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e3deefba9c832aac8cf39d0359587e