### PR TITLE
Replace Kommunicate integration with Dialogflow chat

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,11 +3,11 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
-    "start": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 EXPO_PUBLIC_KOMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 EXPO_PUBLIC_COMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 expo start -c",
-    "dev": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 EXPO_PUBLIC_KOMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 EXPO_PUBLIC_COMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 expo start -c",
-    "android": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 EXPO_PUBLIC_KOMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 EXPO_PUBLIC_COMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 expo start -c --android",
-    "ios": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 EXPO_PUBLIC_KOMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 EXPO_PUBLIC_COMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 expo start -c --ios",
-    "web": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 EXPO_PUBLIC_KOMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 EXPO_PUBLIC_COMMUNICATE_APP_ID=1bc1af724f54a2ea777cb03d818d6a3a0 expo start -c --web",
+    "start": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c",
+    "dev": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c",
+    "android": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --android",
+    "ios": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --ios",
+    "web": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --web",
     "clean": "rm -rf .expo node_modules"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- replace the Kommunicate web widget on the home screen with a native chat experience that streams messages through the Dialogflow backend service and maintains session context, loading, and error handling
- pass profile metadata to the chat widget and simplify Expo scripts by removing unused Kommunicate environment variables

## Testing
- `cd frontend && npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68e4f8ea4044832a9f0e3d1fb98de441