### PR TITLE
Fix JWT expiry handling in authentication service

### DIFF
--- a/backend/src/services/authentication.service.js
+++ b/backend/src/services/authentication.service.js
@@ -161,12 +161,15 @@ class AuthenticationService {
       return null;
     }
 
+    const expiresAtDate =
+      expires_at instanceof Date ? expires_at : new Date(expires_at * 1000);
+
     return await new JwtModel(
       user_id,
       session_id,
       token,
       type,
-      new Date(expires_at * 1000),
+      expiresAtDate,
     ).save();
   }
 

--- a/backend/test/services/authentication.test.js
+++ b/backend/test/services/authentication.test.js
@@ -222,6 +222,22 @@ describe("AuthenticationService", function () {
       expect(jwtSaved.jwt).to.be.equal(token);
     });
 
+    it("should accept Date instances for expires_at", async () => {
+      const token = jwt.sign({ sub: 1 }, "fakesecret");
+      const expiry = new Date("2025-01-01T00:00:00.000Z");
+
+      const jwtSaved = await authenticationService.saveToken(
+        1,
+        "xxx-xxx",
+        token,
+        "access",
+        expiry,
+      );
+
+      expect(jwtSaved).to.be.instanceOf(JwtModel);
+      expect(jwtSaved.expires_at).to.equal(expiry);
+    });
+
     it("should return null when missing any arugment", async () => {
       const jwtSaved = await authenticationService.saveToken(1, 5000);
 


### PR DESCRIPTION
## Summary
- normalize the expiry value in the authentication service before persisting JWT metadata
- add a regression test to ensure saveToken accepts Date instances for expirations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e74f3155a0832a9dccad0e82c9b23c