### PR TITLE
Fix lost article deletion ID validation

### DIFF
--- a/backend/src/services/lost-articles.service.js
+++ b/backend/src/services/lost-articles.service.js
@@ -191,14 +191,16 @@ class LostArticleService {
    * @returns {Promise<boolean>}
    */
   async deleteById(id) {
-    if (!id || Number.isNaN(id)) {
+    const numericId = Number(id);
+
+    if (!id || Number.isNaN(numericId)) {
       throw new HttpError({
         code: 400,
         clientMessage: "lostArticleId must be included",
       });
     }
 
-    const result = await LostItemModel.deleteWhere("id", id);
+    const result = await LostItemModel.deleteWhere("id", numericId);
 
     return result?.changes !== 0;
   }

--- a/backend/test/services/lost-article.test.js
+++ b/backend/test/services/lost-article.test.js
@@ -5,6 +5,7 @@ const chaiAsPromised = require("chai-as-promised").default;
 const setupBaseModelStubs = require("../testing-utils/baseModelMocks");
 const lostArticleService = require("src/services/lost-articles.service");
 const personalDetailsService = require("src/services/personal-details.service");
+const HttpError = require("src/utils/http-error");
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
@@ -96,6 +97,13 @@ describe("LostArticleService", () => {
 
     it("should throw if lostArticleId missing", async () => {
       await expect(lostArticleService.deleteById()).to.be.rejected;
+    });
+
+    it("should throw if lostArticleId is not a number", async () => {
+      await expect(lostArticleService.deleteById("abc")).to.be.rejectedWith(
+        HttpError,
+        "lostArticleId must be included",
+      );
     });
 
     it("should propagate errors", async () => {


### PR DESCRIPTION
## Summary
- ensure lost article deletions validate numeric identifiers before hitting the database
- normalize the id to a number when deleting lost articles
- extend service tests to cover non-numeric ids throwing an HttpError

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e78faccb70832aba5e24b5236d3c60