### PR TITLE
Restrict lost article updates to officers

### DIFF
--- a/backend/src/routes/lost-articles.route.js
+++ b/backend/src/routes/lost-articles.route.js
@@ -33,7 +33,11 @@ lostArticlesRouter.get("/all", lostArticlesControler.getAll);
 
 lostArticlesRouter.get("/:id", lostArticlesControler.getById);
 
-lostArticlesRouter.patch("/:id", lostArticlesControler.update);
+lostArticlesRouter.patch(
+  "/:id",
+  OfficerAuthenticationMiddleware,
+  lostArticlesControler.update,
+);
 
 lostArticlesRouter.patch(
   "/:id/status",


### PR DESCRIPTION
## Summary
- require officer authentication before allowing lost article updates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7bd7b8f78832aa61e6065aa98699f