### PR TITLE
Restrict citizen editing to lost item details

### DIFF
--- a/frontend/app/(app)/lost-found/view.tsx
+++ b/frontend/app/(app)/lost-found/view.tsx
@@ -189,8 +189,16 @@ export default function LostFoundView() {
   const canUpdateStatus = role === "officer" && section === "searching";
   const canAddNotes = role === "officer" && (section === "searching" || section === "returned");
 
+  const canCitizenEdit = role === "citizen" && type === "lost";
+
+  useEffect(() => {
+    if (!canCitizenEdit && editing) {
+      setEditing(false);
+    }
+  }, [canCitizenEdit, editing]);
+
   const saveEdit = async () => {
-    if (!item) return;
+    if (!item || !canCitizenEdit) return;
     setSaving(true);
     try {
       const payload: Partial<LostItemUpdatePayload> = {};
@@ -237,7 +245,7 @@ export default function LostFoundView() {
   };
 
   const cancelEdit = () => {
-    if (!item) return;
+    if (!item || !canCitizenEdit) return;
     setDraft({
       name: item.name ?? "",
       description: item.description ?? "",
@@ -391,7 +399,7 @@ export default function LostFoundView() {
         </Animated.View>
 
         {/* Citizen edit */}
-        {role === "citizen" ? (
+        {canCitizenEdit ? (
           <View className="flex-row flex-wrap items-center gap-2 mt-4">
             {editing ? (
               <>


### PR DESCRIPTION
## Summary
- disable citizen editing controls on found-item detail views
- guard save and cancel handlers so only lost items can be edited
- reset editing state when citizens load read-only found records

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7d11d193c832a9b578a27a998e413