### PR TITLE
Allow HTTP API URLs on private networks

### DIFF
--- a/frontend/services/apiService.ts
+++ b/frontend/services/apiService.ts
@@ -3,16 +3,56 @@ import * as SecureStore from 'expo-secure-store';
 
 import { getCachedTokens, primeTokenCache } from '@/lib/token-cache';
 
+function isPrivateHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  const loopbackHosts = new Set(['localhost', '127.0.0.1', '::1']);
+  if (loopbackHosts.has(normalized)) {
+    return true;
+  }
+
+  const ipv4Match = normalized.match(
+    /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/,
+  );
+  if (ipv4Match) {
+    const octets = ipv4Match.slice(1).map(Number);
+    const [a, b] = octets;
+    if (a === 10) {
+      return true;
+    }
+    if (a === 172 && b >= 16 && b <= 31) {
+      return true;
+    }
+    if (a === 192 && b === 168) {
+      return true;
+    }
+    if (a === 169 && b === 254) {
+      return true;
+    }
+  }
+
+  // Covers IPv6 Unique Local Addresses (fc00::/7) and Link-Local (fe80::/10)
+  if (normalized.startsWith('fc') || normalized.startsWith('fd')) {
+    return true;
+  }
+  if (normalized.startsWith('fe8') || normalized.startsWith('fe9') || normalized.startsWith('fea') || normalized.startsWith('feb')) {
+    return true;
+  }
+
+  return false;
+}
+
 function resolveBaseUrl(): string {
-  const candidate = process.env.EXPO_PUBLIC_API_URL ?? 'https://localhost:2699';
+  const candidate = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:2699';
 
   try {
     const parsed = new URL(candidate);
-    const isLocalhost = ['localhost', '127.0.0.1'].includes(parsed.hostname);
-    if (parsed.protocol !== 'https:' && !isLocalhost) {
-      throw new Error('Insecure API URL. HTTPS is required.');
+    const { protocol, hostname } = parsed;
+
+    if (protocol === 'https:' || (protocol === 'http:' && isPrivateHostname(hostname))) {
+      return candidate;
     }
-    return candidate;
+
+    throw new Error('Insecure API URL. HTTPS is required.');
   } catch (error) {
     throw new Error(
       `Invalid EXPO_PUBLIC_API_URL provided: ${candidate}. ${(error as Error).message}`,


### PR DESCRIPTION
## Summary
- add private network hostname detection for EXPO_PUBLIC_API_URL validation
- permit HTTP URLs when pointing to loopback or private network hosts so local devices can connect

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ee15e9202c832a8f5f0bbb37c4842d