### PR TITLE
Configure Expo startup for device access and APK builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,16 @@ npm run model:train
 # Start the development server
 npm run dev
 
-# Start the frontend server
-npx cross-env EXPO_PUBLIC_API_URL=http://192.168.56.1:2699 expo start -c
+# Start the frontend server (runs from /frontend)
+npm run dev
 
 # Generate mock data
 npm run script:generateExampleData
 ```
 
 You can then visit `localhost:2699/api-docs` and view all available endpoints
+
+> **Note:** The frontend startup script automatically detects your machine's
+> local IP address and shares it with Expo so phones on the same network can
+> reach the backend. Override the detection with `GUARDIAN_API_HOST` or supply
+> a full URL via `EXPO_PUBLIC_API_URL` if needed.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -36,16 +36,39 @@ This will start the Expo Dev Server. Open the app in:
 
 You can also scan the QR code using the [Expo Go](https://expo.dev/go) app on your device. This project fully supports running in Expo Go for quick testing on physical devices.
 
+> The start script automatically detects your computer's local IP address and
+> shares it with Expo so phones on the same network can reach the backend API.
+> Set `GUARDIAN_API_HOST` to force a specific host or `EXPO_PUBLIC_API_URL` to
+> supply a fully-qualified URL.
+
 ### Backend API
 
-This frontend expects a backend API base URL provided via the `EXPO_PUBLIC_API_URL` environment variable. When running on a physical device or simulator, set this to the host machine's IP address, for example:
+This frontend expects a backend API base URL provided via the `EXPO_PUBLIC_API_URL` environment variable. The startup script sets this automatically based on your local network configuration, but you can override it manually:
 
 ```bash
-export EXPO_PUBLIC_API_URL="http://192.168.1.100:3000"
+export GUARDIAN_API_HOST="192.168.1.100" # or set EXPO_PUBLIC_API_URL directly
 npm run dev
 ```
 
-If the variable is not set, network requests will fail.
+If the variable is not set when bundling a production build, the app will fail to boot. Always provide a reachable backend URL for release builds.
+
+## Build an Android APK
+
+The project ships with an [EAS Build](https://docs.expo.dev/build/introduction/) configuration that produces installable APKs for testing on physical devices:
+
+```bash
+cd frontend
+npx expo install expo-dev-client # first time only, ensures native deps are synced
+npx eas build -p android --profile preview
+```
+
+The `preview` profile creates an unsigned APK stored in the Expo dashboard. Download it from the build logs or run with the `--local` flag to build entirely on your machine:
+
+```bash
+npx eas build -p android --profile preview --local
+```
+
+Before running a production build, update `EXPO_PUBLIC_API_URL` (or the corresponding secret in Expo) to point at your deployed backend.
 
 ## Adding components
 

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -1,11 +1,11 @@
 {
   "expo": {
-    "name": ".",
-    "slug": ".",
+    "name": "Guardian",
+    "slug": "guardian",
     "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
-    "scheme": ".",
+    "scheme": "guardian",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "splash": {
@@ -20,6 +20,7 @@
       "supportsTablet": true
     },
     "android": {
+      "package": "com.guardian.community",
       "edgeToEdgeEnabled": true,
       "adaptiveIcon": {
         "foregroundImage": "./assets/images/adaptive-icon.png",

--- a/frontend/eas.json
+++ b/frontend/eas.json
@@ -1,0 +1,18 @@
+{
+  "cli": {
+    "version": ">= 12.5.0"
+  },
+  "build": {
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,11 +3,11 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
-    "start": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c",
-    "dev": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c",
-    "android": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --android",
-    "ios": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --ios",
-    "web": "cross-env EXPO_PUBLIC_API_URL=http://localhost:2699 expo start -c --web",
+    "start": "node ./scripts/start.js",
+    "dev": "node ./scripts/start.js",
+    "android": "node ./scripts/start.js --android",
+    "ios": "node ./scripts/start.js --ios",
+    "web": "node ./scripts/start.js --web",
     "clean": "rm -rf .expo node_modules"
   },
   "dependencies": {

--- a/frontend/scripts/start.js
+++ b/frontend/scripts/start.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/*
+ * Helper script to start the Expo dev server with a network-accessible
+ * backend URL so physical devices can connect without additional setup.
+ */
+const { networkInterfaces } = require('os');
+const { spawn } = require('child_process');
+
+const DEFAULT_API_PORT = process.env.GUARDIAN_API_PORT ?? '2699';
+const CLI = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+
+function isPrivateAddress(address) {
+  if (!address) return false;
+  if (address.startsWith('10.')) return true;
+  if (address.startsWith('192.168.')) return true;
+  if (address.startsWith('172.')) {
+    const secondOctet = Number(address.split('.')[1]);
+    return secondOctet >= 16 && secondOctet <= 31;
+  }
+  if (address.startsWith('169.254.')) return true;
+  return false;
+}
+
+function getLocalAddress() {
+  if (process.env.GUARDIAN_API_HOST) {
+    return process.env.GUARDIAN_API_HOST;
+  }
+
+  const nets = networkInterfaces();
+  const candidates = [];
+
+  for (const entries of Object.values(nets)) {
+    for (const entry of entries ?? []) {
+      if (entry.family === 'IPv4' && !entry.internal) {
+        candidates.push(entry.address);
+      }
+    }
+  }
+
+  if (candidates.length === 0) {
+    return '127.0.0.1';
+  }
+
+  const preferred = candidates.find((address) => isPrivateAddress(address));
+  return preferred ?? candidates[0];
+}
+
+function buildApiUrl() {
+  if (process.env.EXPO_PUBLIC_API_URL) {
+    return process.env.EXPO_PUBLIC_API_URL;
+  }
+
+  const host = getLocalAddress();
+  return `http://${host}:${DEFAULT_API_PORT}`;
+}
+
+function run() {
+  const apiUrl = buildApiUrl();
+  const expoArgs = ['expo', 'start', '-c', ...process.argv.slice(2)];
+
+  console.log(`\nUsing backend API: ${apiUrl}`);
+  console.log('You can override this via EXPO_PUBLIC_API_URL or GUARDIAN_API_HOST.\n');
+
+  const child = spawn(CLI, expoArgs, {
+    stdio: 'inherit',
+    env: { ...process.env, EXPO_PUBLIC_API_URL: apiUrl },
+  });
+
+  child.on('exit', (code) => {
+    process.exit(code ?? 0);
+  });
+}
+
+run();

--- a/frontend/services/apiService.ts
+++ b/frontend/services/apiService.ts
@@ -42,7 +42,13 @@ function isPrivateHostname(hostname: string): boolean {
 }
 
 function resolveBaseUrl(): string {
-  const candidate = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:2699';
+  const candidate = process.env.EXPO_PUBLIC_API_URL;
+
+  if (!candidate) {
+    throw new Error(
+      'EXPO_PUBLIC_API_URL is not configured. Start the project with `npm run dev` or set the variable manually.',
+    );
+  }
 
   try {
     const parsed = new URL(candidate);


### PR DESCRIPTION
## Summary
- add a cross-platform startup script that shares the backend URL with Expo so phones on the same network work out of the box
- document the new workflow, add EAS build configuration, and update Expo metadata for Android packages/APK generation
- require an explicit API URL in the frontend service to avoid misconfigured release builds

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ee1926e77c832a903da7b9d7a455d7